### PR TITLE
fix: render HA charging/lock as real toggles, not assumed-state buttons

### DIFF
--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -59,7 +59,8 @@ static void publishDiscoveryEntity(PubSubClient& mqtt, const char* component,
 static void publishDiscoverySwitch(PubSubClient& mqtt, const char* objectId,
     const char* name, const char* icon, const char* cmdTopic,
     const char* stateTopic, const char* valTemplate,
-    const char* payloadOn = "1", const char* payloadOff = "0") {
+    const char* payloadOn = "1", const char* payloadOff = "0",
+    const char* stateOn = "1", const char* stateOff = "0") {
 
     const WBConfig& cfg = configMgr.get();
     String topic = cfg.haDiscoveryPrefix + "/switch/" + cfg.haDeviceId + "/" + objectId + "/config";
@@ -73,6 +74,8 @@ static void publishDiscoverySwitch(PubSubClient& mqtt, const char* objectId,
     doc["value_template"] = valTemplate;
     doc["payload_on"] = payloadOn;
     doc["payload_off"] = payloadOff;
+    doc["state_on"] = stateOn;
+    doc["state_off"] = stateOff;
     doc["availability_topic"] = availTopic();
     if (icon) doc["icon"] = icon;
 


### PR DESCRIPTION
The Charging and Charger Lock MQTT switches showed as a pair of on/off buttons instead of a sliding toggle because HA reported their state as unknown. The discovery config only set payload_on/payload_off (the command strings: start/stop, lock/unlock), and HA defaults state_on/state_off to those same strings. But the value_template emits "1"/"0", which matched neither -- so the entity state never resolved.

Add explicit state_on/state_off (default "1"/"0") to publishDiscoverySwitch, decoupling the command payloads from the state values the template reports. Both switches now match and render as proper toggles.