### PR TITLE
fix: make HA Auto Lock controls work (state, write, minutes)

### DIFF
--- a/docs/HOME_ASSISTANT.md
+++ b/docs/HOME_ASSISTANT.md
@@ -39,7 +39,7 @@ and reduce responsiveness.
 - `switch.wallbox_power_sharing` — dynamic power sharing
 - `switch.wallbox_phase_switch`
 - `number.wallbox_max_charging_current` — 6-32A slider
-- `number.wallbox_autolock_timeout` — 10-600s
+- `number.wallbox_autolock_timeout` — 1-60 min
 - `number.wallbox_eco_smart_solar_percent` — 0-100%
 - `select.wallbox_eco_smart_mode` — Off / Solar + Grid / Full Green
 - `select.wallbox_halo_led` — Off / Low / Medium / High

--- a/include/wb_mqtt.h
+++ b/include/wb_mqtt.h
@@ -24,6 +24,10 @@ public:
     // Send HA MQTT auto-discovery configs
     void sendDiscovery();
 
+    // Last auto-lock timeout (seconds) seen from polling. Used so toggling
+    // the Auto Lock switch ON restores the real timeout instead of a default.
+    int lastAutolockTime = 60;
+
 private:
     void _connect();
     void _subscribe();

--- a/include/wb_mqtt.h
+++ b/include/wb_mqtt.h
@@ -24,9 +24,9 @@ public:
     // Send HA MQTT auto-discovery configs
     void sendDiscovery();
 
-    // Last auto-lock timeout (seconds) seen from polling. Used so toggling
+    // Last auto-lock timeout (minutes) seen from polling. Used so toggling
     // the Auto Lock switch ON restores the real timeout instead of a default.
-    int lastAutolockTime = 60;
+    int lastAutolockMin = 1;
 
 private:
     void _connect();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,12 +74,18 @@ static void pollSettings() {
     String r1 = wallboxBLE.sendCommand(bapi::MET_GET_AUTOLOCK);
     if (!r1.isEmpty()) {
         JsonDocument d; if (deserializeJson(d, r1) == DeserializationError::Ok) {
+            // g_alo returns the lock timeout in seconds as a bare scalar:
+            // 0 = auto-lock off, >0 = on and locks after that many seconds.
+            // (Object shape kept as a defensive fallback.)
             if (d["r"].is<JsonObject>()) {
-                merged["autolock"] = d["r"]["enabled"] | 0;
-                merged["autolock_time"] = d["r"]["time"] | 60;
+                int t = d["r"]["time"] | 0;
+                bool en = d["r"]["enabled"].as<bool>() || t > 0;
+                merged["autolock"] = en ? 1 : 0;
+                merged["autolock_time"] = (t >= 10) ? t : 60;
             } else {
-                merged["autolock"] = d["r"] | 0;
-                merged["autolock_time"] = 60;
+                int t = d["r"].as<int>();
+                merged["autolock"] = t > 0 ? 1 : 0;
+                merged["autolock_time"] = (t >= 10) ? t : 60;
             }
         }
     }
@@ -95,14 +101,14 @@ static void pollSettings() {
     String r3 = wallboxBLE.sendCommand("g_psh", "null");
     if (!r3.isEmpty()) {
         JsonDocument d; if (deserializeJson(d, r3) == DeserializationError::Ok) {
-            merged["power_sharing"] = d["r"]["dyps"] | 0;
+            merged["power_sharing"] = d["r"]["dyps"].as<bool>() ? 1 : 0;
         }
     }
 
     String r4 = wallboxBLE.sendCommand("g_phsw", "null");
     if (!r4.isEmpty()) {
         JsonDocument d; if (deserializeJson(d, r4) == DeserializationError::Ok) {
-            merged["phase_switch"] = d["r"]["enabled"] | 0;
+            merged["phase_switch"] = d["r"]["enabled"].as<bool>() ? 1 : 0;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,9 +86,14 @@ static void pollSettings() {
                 t = d["r"].as<int>();
                 merged["autolock"] = t > 0 ? 1 : 0;
             }
-            merged["autolock_time"] = (t >= 10) ? t : 60;
-            // Remember a real timeout so an HA switch-ON can restore it.
-            if (t >= 10) wallboxMQTT.lastAutolockTime = t;
+            // The charger stores seconds (multiples of 60); HA shows minutes
+            // to match the Wallbox app. Keep the last value while it's off.
+            if (t > 0) {
+                int mins = (t + 30) / 60;
+                if (mins < 1) mins = 1;
+                wallboxMQTT.lastAutolockMin = mins;
+            }
+            merged["autolock_time"] = wallboxMQTT.lastAutolockMin;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,16 +77,18 @@ static void pollSettings() {
             // g_alo returns the lock timeout in seconds as a bare scalar:
             // 0 = auto-lock off, >0 = on and locks after that many seconds.
             // (Object shape kept as a defensive fallback.)
+            int t;
             if (d["r"].is<JsonObject>()) {
-                int t = d["r"]["time"] | 0;
+                t = d["r"]["time"] | 0;
                 bool en = d["r"]["enabled"].as<bool>() || t > 0;
                 merged["autolock"] = en ? 1 : 0;
-                merged["autolock_time"] = (t >= 10) ? t : 60;
             } else {
-                int t = d["r"].as<int>();
+                t = d["r"].as<int>();
                 merged["autolock"] = t > 0 ? 1 : 0;
-                merged["autolock_time"] = (t >= 10) ? t : 60;
             }
+            merged["autolock_time"] = (t >= 10) ? t : 60;
+            // Remember a real timeout so an HA switch-ON can restore it.
+            if (t >= 10) wallboxMQTT.lastAutolockTime = t;
         }
     }
 

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -346,20 +346,22 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
 
     // ---- Native HA entity handlers (Batch 1) ----
     } else if (sub == "autolock_enable") {
-        // s_alo takes a bare scalar: 0 = off, N = on and lock after N seconds.
+        // s_alo takes seconds: 0 = off, N = on and lock after N seconds.
         // Toggling ON restores the last-known timeout instead of resetting it.
         String s = payload; s.toLowerCase();
         bool on = (s == "1" || s == "on" || s == "true");
-        int secs = on ? (lastAutolockTime >= 10 ? lastAutolockTime : 60) : 0;
+        int mins = lastAutolockMin >= 1 ? lastAutolockMin : 1;
+        int secs = on ? mins * 60 : 0;
         wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, String(secs).c_str());
 
     } else if (sub == "autolock_time") {
-        // Setting a timeout implies enabling auto-lock (scalar: N = on after Ns).
-        int secs = atoi(payload);
-        if (secs < 10) secs = 60;
-        if (secs > 600) secs = 600;
-        lastAutolockTime = secs;
-        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, String(secs).c_str());
+        // HA sends minutes (matching the Wallbox app); the charger wants
+        // seconds. Setting a timeout implies enabling auto-lock.
+        int mins = atoi(payload);
+        if (mins < 1) mins = 1;
+        if (mins > 60) mins = 60;
+        lastAutolockMin = mins;
+        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, String(mins * 60).c_str());
 
     } else if (sub == "eco_mode") {
         // HA sends: "Off", "Full Green (Solar Only)", "Solar + Grid"
@@ -611,7 +613,7 @@ void WallboxMQTT::sendDiscovery() {
     // Auto Lock timeout (number)
     publishDiscoveryNumber(*_client, "autolock_time", "Auto Lock Timeout",
         "mdi:timer-lock", cmdAutolockTime.c_str(), sTopic_,
-        "{{ value_json.autolock_time | default(60) }}", 10, 600, 10, "s", "box");
+        "{{ value_json.autolock_time | default(1) }}", 1, 60, 1, "min", "box");
 
     // Eco Smart Mode (select). BAPI esm: 0=Off, 1=Full Green, 2=Solar+Grid
     static const char* ecoOptions[] = {"Off", "Full Green (Solar Only)", "Solar + Grid"};

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -346,17 +346,20 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
 
     // ---- Native HA entity handlers (Batch 1) ----
     } else if (sub == "autolock_enable") {
-        // switch: "1"/"ON" = enable, else disable. Reuses existing time value.
+        // s_alo takes a bare scalar: 0 = off, N = on and lock after N seconds.
+        // Toggling ON restores the last-known timeout instead of resetting it.
         String s = payload; s.toLowerCase();
-        int en = (s == "1" || s == "on" || s == "true") ? 1 : 0;
-        String p = "{\"enabled\":" + String(en) + ",\"time\":60}";
-        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, p.c_str());
+        bool on = (s == "1" || s == "on" || s == "true");
+        int secs = on ? (lastAutolockTime >= 10 ? lastAutolockTime : 60) : 0;
+        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, String(secs).c_str());
 
     } else if (sub == "autolock_time") {
+        // Setting a timeout implies enabling auto-lock (scalar: N = on after Ns).
         int secs = atoi(payload);
         if (secs < 10) secs = 60;
-        String p = "{\"enabled\":1,\"time\":" + String(secs) + "}";
-        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, p.c_str());
+        if (secs > 600) secs = 600;
+        lastAutolockTime = secs;
+        wallboxBLE.sendCommand(bapi::MET_SET_AUTOLOCK, String(secs).c_str());
 
     } else if (sub == "eco_mode") {
         // HA sends: "Off", "Full Green (Solar Only)", "Solar + Grid"

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -92,7 +92,8 @@ static void publishDiscoverySwitch(PubSubClient& mqtt, const char* objectId,
 static void publishDiscoveryNumber(PubSubClient& mqtt, const char* objectId,
     const char* name, const char* icon, const char* cmdTopic,
     const char* stateTopic, const char* valTemplate,
-    float minVal, float maxVal, float step, const char* unit = nullptr) {
+    float minVal, float maxVal, float step, const char* unit = nullptr,
+    const char* mode = nullptr) {
 
     const WBConfig& cfg = configMgr.get();
     String topic = cfg.haDiscoveryPrefix + "/number/" + cfg.haDeviceId + "/" + objectId + "/config";
@@ -110,6 +111,8 @@ static void publishDiscoveryNumber(PubSubClient& mqtt, const char* objectId,
     doc["availability_topic"] = availTopic();
     if (icon) doc["icon"] = icon;
     if (unit) doc["unit_of_measurement"] = unit;
+    // "box" renders an exact-value input field instead of HA's default slider.
+    if (mode) doc["mode"] = mode;
 
     JsonObject dev = doc["device"].to<JsonObject>();
     dev["identifiers"][0] = configMgr.get().haDeviceId;
@@ -605,7 +608,7 @@ void WallboxMQTT::sendDiscovery() {
     // Auto Lock timeout (number)
     publishDiscoveryNumber(*_client, "autolock_time", "Auto Lock Timeout",
         "mdi:timer-lock", cmdAutolockTime.c_str(), sTopic_,
-        "{{ value_json.autolock_time | default(60) }}", 10, 600, 10, "s");
+        "{{ value_json.autolock_time | default(60) }}", 10, 600, 10, "s", "box");
 
     // Eco Smart Mode (select). BAPI esm: 0=Off, 1=Full Green, 2=Solar+Grid
     static const char* ecoOptions[] = {"Off", "Full Green (Solar Only)", "Solar + Grid"};


### PR DESCRIPTION
The Home Assistant Auto Lock switch and timeout were out of sync with the charger and the official Wallbox app. This fixes the full round-trip.

### Changes
- **State sync** — `g_alo` returns the timeout as a bare scalar (`{"r":60}`, `0` = off). The poll mis-parsed it, so the switch stuck OFF and the timeout always showed a default. Now parsed correctly for both the switch and the number.
- **Working write path** — `s_alo` expects a bare scalar, but HA was sending an object, so writes were silently ignored. Now sends the scalar the charger accepts. Toggling the switch ON restores the last-known timeout instead of resetting it.
- **Minutes** — the timeout is now expressed in minutes (1–60) to match the Wallbox app, converted to seconds at the BLE boundary. Rendered as an input box rather than a slider.

### Testing
Verified on a Pulsar MAX: changing auto-lock in the app reflects in HA, and setting the HA timeout/switch round-trips back to the charger and the app.