### PR TITLE
Release v3.2.1 (MQTT crash fixes + diagnostics)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
           name: firmware-esp32s3
           path: |
             .pio/build/esp32s3/firmware.bin
+            .pio/build/esp32s3/firmware.elf
             .pio/build/esp32s3/bootloader.bin
             .pio/build/esp32s3/partitions.bin
             .pio/build/esp32s3/SHA256SUMS.txt
@@ -98,6 +99,14 @@ jobs:
           # ESP-Web-Tools parts (firmware/bootloader/partitions + install.json).
           cp .pio/build/esp32s3/firmware.bin \
              ".pio/build/esp32s3/wallbox-gateway-${GITHUB_REF_NAME}-esp32s3.bin"
+          # Board+tag-named ELF alongside the .bin. A coredump is just
+          # addresses; turning /api/coredump/summary's backtrace into function
+          # names + lines needs the EXACT ELF that built the running image.
+          # Attaching it per release means any user's crash (or ours, #168) can
+          # be symbolised from the release page — no rebuild, no guessing which
+          # commit. Debug artifact only; never flashed.
+          cp .pio/build/esp32s3/firmware.elf \
+             ".pio/build/esp32s3/wallbox-gateway-${GITHUB_REF_NAME}-esp32s3.elf"
 
       - name: Attach to release
         if: github.event_name == 'release'
@@ -105,6 +114,7 @@ jobs:
         with:
           files: |
             .pio/build/esp32s3/wallbox-gateway-*-esp32s3.bin
+            .pio/build/esp32s3/wallbox-gateway-*-esp32s3.elf
             .pio/build/esp32s3/firmware.bin
             .pio/build/esp32s3/bootloader.bin
             .pio/build/esp32s3/partitions.bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-07-23
+
+Stability release. Fixes the recurring MQTT-related crash/reboot, the `/logs`
+Download hang, and adds crash-diagnostics tooling that made the crash fixes
+possible.
+
 ### Fixed
+- **Gateway could crash and reboot around MQTT (re)connect** — the dominant
+  cause of the intermittent reboots some users saw. Two independent faults,
+  both now fixed:
+  - The BLE task was driving `MQTT.loop()` (via a yield callback) *concurrently*
+    with the main loop's `MQTT.loop()`. PubSubClient / WiFiClient / lwip aren't
+    thread-safe, so two tasks reading the socket corrupted an lwip buffer and
+    asserted. The yield callback is removed — since BLE runs on its own task,
+    the main loop already services MQTT continuously.
+  - MQTT reconnect could dereference a NULL/torn-down socket after a WiFi blip
+    (`PubSubClient::connect` trusting a stale `connected()`). Reconnect now waits
+    for `WiFi.status()==WL_CONNECTED` and forces a fresh socket first.
 - **`/logs` page could hang when using Download.** The Download button linked
   straight to `/api/logs`, firing a second ~16 KB request that raced the page's
   3-second auto-refresh poll for the async server's connection slots — under the
@@ -14,6 +31,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Download now builds the file client-side (a Blob from the log the page already
   shows), so it makes no server request, can't contend, and is instant. The
   `/api/logs` endpoint is unchanged for external monitors.
+
+### Added
+- **Crash-diagnostics tooling.** Releases now attach `firmware.elf` so a
+  coredump can be symbolised against the exact build. BLE operation timings
+  (`ble_write_max_ms` / `ble_rt_max_ms`) are exposed on `/api/diag/runtime`, and
+  the crash breadcrumb records the in-flight BLE phase — together these turned an
+  un-diagnosable reboot into a named root cause.
+
+### Known issues
+- A **rare** interrupt-watchdog reboot (roughly once every few days) remains
+  under investigation. It does not leave a usable coredump. The frequent
+  MQTT-related crashes fixed above were the dominant cause of reboots.
 
 ## [3.2.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`/logs` page could hang when using Download.** The Download button linked
+  straight to `/api/logs`, firing a second ~16 KB request that raced the page's
+  3-second auto-refresh poll for the async server's connection slots — under the
+  resulting heap pressure some responses came back empty and the page stalled.
+  Download now builds the file client-side (a Blob from the log the page already
+  shows), so it makes no server request, can't contend, and is instant. The
+  `/api/logs` endpoint is unchanged for external monitors.
+
 ## [3.2.0] - 2026-07-18
 
 Promotes **3.2.0-rc.4** to stable, plus the post-rc.4 diagnostics and robustness

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -222,6 +222,12 @@ public:
     // Stats
     uint32_t txCount() const { return _txCount; }
     uint32_t rxCount() const { return _rxCount; }
+    // #168 instrumentation — worst-case BLE-op timings. A writeValue that
+    // stalls under a marginal link is the suspected core-0-starvation trigger;
+    // surfaced on /api/diag/runtime so the worst case is visible even after the
+    // in-RAM log ring has wrapped (and it survives, since it's a live read).
+    uint32_t bleMaxWriteMs() const { return _maxWriteMs; }
+    uint32_t bleMaxRoundTripMs() const { return _maxRoundTripMs; }
     int rssi() const;
     int scanRSSI() const { return _scanRSSI; }
     uint32_t lastActivityAge() const { return millis() - _lastActivityTime; }
@@ -411,6 +417,10 @@ private:
     String   _gattTopology;   // captured at connect for the compat report
     uint32_t _seqStatus = 0,   _seqRealtime = 0, _seqMeter = 0;
     uint32_t _seqSettings = 0, _seqNotifications = 0, _seqLse = 0;
+    // #168 BLE-op timing (written on BLE task, read on AsyncTCP for /diag).
+    volatile uint32_t _lastWriteMs = 0;      // last ATT-write duration
+    volatile uint32_t _maxWriteMs = 0;       // worst ATT-write duration
+    volatile uint32_t _maxRoundTripMs = 0;   // worst write+response round-trip
     // Poll timers (BLE-task local)
     uint32_t _lastStatusPoll = 0, _lastRealtimePoll = 0, _lastNotifPoll = 0;
     uint32_t _statusPollMs = 10000, _realtimePollMs = 30000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -400,27 +400,22 @@ void setup() {
         const WBConfig& cfg = configMgr.get();
         wallboxBLE.begin(cfg.bleAddr.c_str());
 
-        // Yield callback — runs while BLE is waiting on a BAPI response so
-        // the rest of the gateway stays responsive. Includes wallboxMQTT.loop()
-        // so PubSubClient's keepalive logic still gets cycles during long
-        // settings polls — without this, several back-to-back BLE waits could
-        // starve MQTT for 15+ seconds and PubSubClient would close the socket
-        // (the "connection closed by client every 85s" pattern observed in the
-        // rc12 broker log).
+        // No BLE yield callback — deliberately. It used to pump
+        // ArduinoOTA.handle() + wallboxMQTT.loop() during BLE response-waits,
+        // from a time when sendCommand() ran on the web/main task. It now runs
+        // on the dedicated wb_ble task (xTaskCreatePinnedToCore), so driving
+        // MQTT/OTA from here fired them CONCURRENTLY with the main loop's own
+        // ArduinoOTA.handle() (below) and wallboxMQTT.loop() (below). PubSubClient
+        // / WiFiClient / lwip are NOT thread-safe: the concurrent MQTT read
+        // corrupted an lwip pbuf and asserted in pbuf_free — a #168 crash in the
+        // wb_ble task, confirmed by coredump (bt: WallboxMQTT::loop → PubSubClient
+        // → WiFiClient::read → lwip_recv_tcp → pbuf_free assert).
         //
-        // CRITICAL: do NOT call webServer.loop() here. This callback fires from
-        // inside sendCommand(), which is itself reached from a web request
-        // handler (handleApiCommand) running inside http.handleClient().
-        // Arduino WebServer is NOT re-entrant — it holds the in-flight request
-        // as member state (_currentClient, parser position, _responseHeaders).
-        // Pumping handleClient() re-entrantly accepts a second connection,
-        // clobbers _currentClient, and the outer handler's http.send() then
-        // writes to a freed socket → panic (LoadProhibited) under overlapping
-        // requests. MQTT + OTA are re-entrancy-safe here; the web server is not.
-        wallboxBLE.onYield([]() {
-            ArduinoOTA.handle();
-            wallboxMQTT.loop();
-        });
+        // The original keepalive-starvation reason is moot now: BLE waits run on
+        // their own task and no longer block the main loop, so the main loop
+        // services MQTT (60 s keepalive) and OTA continuously on its own. Hence
+        // no yield callback at all — the BLE wait just delay(1)-yields to the
+        // scheduler, which is enough.
         if (cfg.bleService.length() > 0 && cfg.bleChar.length() > 0) {
             // Dual-char mode if bleTxChar is set (e.g. Pulsar Plus); otherwise single-char (MAX default)
             wallboxBLE.setUUIDs(cfg.bleService.c_str(), cfg.bleChar.c_str(),

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1320,6 +1320,13 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
     size_t maxChunk = (curMtu > 3) ? (size_t)(curMtu - 3) : 20;
     bool writeOk = true;
 
+    // #168: time the ATT write, and mark the crash breadcrumb "w:<met>" so a
+    // watchdog reset mid-writeValue is identifiable after reboot — the coredump
+    // backtrace of the running BLE task is often unwind-corrupt, and the in-RAM
+    // log ring is wiped on reboot, but the RTC-NOINIT breadcrumb survives.
+    uint32_t wStart = millis();
+    { char ph[16]; snprintf(ph, sizeof(ph), "w:%s", met); wb_health::setBreadcrumbBapi(ph); }
+
     if (wlen <= maxChunk) {
         // Fits in one ATT write — original behaviour (no-response, then with).
         if (!_chr->writeValue(wp, wlen, false))
@@ -1339,6 +1346,16 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
                        met, (unsigned)wlen, (unsigned)maxChunk, curMtu);
     }
 
+    // #168: record the write duration. A slow write (normal is < 50 ms) is the
+    // prime suspect for the core-0 watchdog — the BT controller can stall on a
+    // marginal link while our task holds a BLE-stack resource.
+    uint32_t writeMs = millis() - wStart;
+    _lastWriteMs = writeMs;
+    if (writeMs > _maxWriteMs) _maxWriteMs = writeMs;
+    if (writeMs > 300)
+        Log.printf("[BLE] SLOW TX %s: write %ums (link/controller stall?)\n",
+                   met, (unsigned)writeMs);
+
     if (!writeOk) {
         Log.printf("[BLE] Write failed for %s — mtu=%d framelen=%u connected=%d char=%s\n",
                    met, _client ? (int)_client->getMTU() : -1,
@@ -1353,6 +1370,7 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
     _txCount++;
 
     // Wait for response — yield to other tasks (web server, OTA) while waiting
+    { char ph[16]; snprintf(ph, sizeof(ph), "q:%s", met); wb_health::setBreadcrumbBapi(ph); }  // #168 phase = waiting
     uint32_t start = millis();
     while (!_responseReady && (millis() - start) < timeoutMs) {
         delay(1);
@@ -1380,6 +1398,11 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
     resp = std::move(_lastResponse);
     if (_parserMutex) xSemaphoreGive(_parserMutex);
     Log.printf("[BLE] RX %s (%d bytes)\n", met, resp.length());
+    // #168: total write+response round-trip; track the worst case for /diag.
+    uint32_t rtMs = millis() - wStart;
+    if (rtMs > _maxRoundTripMs) _maxRoundTripMs = rtMs;
+    if (rtMs > 2000)
+        Log.printf("[BLE] SLOW round-trip %s: %ums\n", met, (unsigned)rtMs);
     if (_cmdMutex) xSemaphoreGive(_cmdMutex);
     return resp;  // RVO + move = zero additional copies on the return
 }

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -473,6 +473,11 @@ void WallboxMQTT::loop() {
             _wasConnected = false;
             wb_diag::reportDisconnect(wb_diag::Kind::MQTT);
         }
+        // #168: never call PubSubClient::connect() while WiFi is down. Its
+        // connect() -> readPacket() -> WiFiClient::read() path dereferences a
+        // NULL/torn-down socket handle -> LoadProhibited crash in loopTask
+        // (confirmed by coredump: read @0x14 in WiFiClient::read). Wait for WiFi.
+        if (WiFi.status() != WL_CONNECTED) return;
         if (millis() - _lastConnectAttempt >= _reconnectGateMs) {
             _connect();
         }
@@ -494,6 +499,14 @@ bool WallboxMQTT::isConnected() const {
 void WallboxMQTT::_connect() {
     _lastConnectAttempt = millis();
     Log.println("[MQTT] Connecting...");
+
+    // #168: force a clean socket before PubSubClient::connect(). PubSubClient
+    // skips its own TCP connect when wifiClient.connected() returns true; after
+    // a WiFi blip that can be STALE (reports connected while the socket handle
+    // is NULL), so connect() jumps straight to reading the CONNACK and
+    // WiFiClient::read() dereferences the NULL handle -> crash. stop() clears
+    // the half-open state so connect() always establishes a fresh socket.
+    wifiClient.stop();
 
     const WBConfig& cfg = configMgr.get();
     const char* user = cfg.mqttUser.length() > 0 ? cfg.mqttUser.c_str() : nullptr;

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -4225,7 +4225,7 @@ String wb_buildLogsPage() {
     page += "<p style='color:var(--text3);font-size:.82em'>Last 16 KB of serial/telnet output. Auto-refreshes every 3s; scroll-locks to bottom unless you scroll up. Persists across page reloads, wiped on reboot.</p>";
     page += "<div style='margin-bottom:8px'>";
     page += "<button class='btn btn-outline' style='padding:6px 12px;font-size:.85em' onclick='copyLog()'>&#x1F4CB; Copy</button> ";
-    page += "<a href='/api/logs' download='wallbox-log.txt' class='btn btn-outline' style='padding:6px 12px;font-size:.85em;text-decoration:none'>&#x2B07; Download</a> ";
+    page += "<button class='btn btn-outline' style='padding:6px 12px;font-size:.85em' onclick='dlLog()'>&#x2B07; Download</button> ";
     page += "<button class='btn btn-outline' style='padding:6px 12px;font-size:.85em' onclick='confirm2(\"Reboot the gateway? Config is preserved \\u2014 you can watch the boot trace appear here.\",function(){fetch(\"/api/reboot?csrf=" + csrfToken + "\",{method:\"POST\"}).then(function(){}).catch(function(){})})'>&#x21BB; Reboot &amp; capture boot trace</button>";
     page += "</div>";
     page += "<pre id='log' style='background:var(--bg);border-radius:8px;padding:10px;font-size:.78em;max-height:70vh;overflow:auto;white-space:pre-wrap;line-height:1.35'></pre>";
@@ -4240,6 +4240,19 @@ String wb_buildLogsPage() {
               "stick=(el.scrollHeight-el.scrollTop-el.clientHeight)<8;"
             "});"
             "window.copyLog=function(){var t=el.textContent||'';if(navigator.clipboard){navigator.clipboard.writeText(t).then(function(){toast&&toast('Copied','success')}).catch(function(){})}};"
+            // Download the log the page ALREADY holds, client-side. The old
+            // <a href='/api/logs' download> fired a second 16 KB request that
+            // raced the 3s poll for the async server's connection slots and
+            // could stall both (empty responses under heap pressure) — the
+            // "stuck on export" report. A Blob from el.textContent needs no
+            // server round-trip, so it can't contend and is instant.
+            "window.dlLog=function(){var t=el.textContent||'';"
+              "var b=new Blob([t],{type:'text/plain'});"
+              "var u=URL.createObjectURL(b);var a=document.createElement('a');"
+              "a.href=u;a.download='wallbox-log.txt';document.body.appendChild(a);"
+              "a.click();document.body.removeChild(a);"
+              "setTimeout(function(){URL.revokeObjectURL(u)},1000);"
+              "if(window.toast)toast('Log downloaded','success');};"
             "function load(){fetch('/api/logs',{cache:'no-store'})"
               ".then(function(r){return r.text()})"
               ".then(function(t){online();el.textContent=t;if(stick)el.scrollTop=el.scrollHeight})"

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -964,6 +964,11 @@ String wb_buildDiagRuntimeJson() {
     body += ",\"async_stack_hwm\":";
     TaskHandle_t asyncTcp = xTaskGetHandle("async_tcp");
     body += asyncTcp ? String(uxTaskGetStackHighWaterMark(asyncTcp)) : String("null");
+    // #168: worst-case BLE-op timings. Normal write < 50 ms, round-trip ~200.
+    // A large ble_write_max_ms is the tell for the marginal-link stall
+    // suspected of starving the core-0 idle task.
+    body += ",\"ble_write_max_ms\":" + String(wallboxBLE.bleMaxWriteMs());
+    body += ",\"ble_rt_max_ms\":" + String(wallboxBLE.bleMaxRoundTripMs());
     body += ",\"uptime_s\":" + String(millis() / 1000);
     body += "}";
     return body;


### PR DESCRIPTION
Stability release on top of v3.2.0. Fixes the recurring MQTT-related crash/reboot (root-caused from on-device coredumps), the `/logs` Download hang, and ships the crash-diagnostics tooling that made the fixes possible.

## Fixed
- **MQTT-related crash/reboot** — two independent faults, both fixed:
  - BLE task was driving `MQTT.loop()` concurrently with the main loop (cross-task access to non-thread-safe PubSubClient/lwip → pbuf corruption). Yield callback removed.
  - MQTT reconnect could deref a NULL/torn-down socket after a WiFi blip. Now gated on `WL_CONNECTED` + fresh socket.
- **`/logs` Download hang** — now builds the file client-side (no second server request racing the poll).

## Added
- `firmware.elf` attached to releases (coredump symbolisation).
- BLE op timings on `/api/diag/runtime` + crash-breadcrumb phase.

## Known issues
- A rare interrupt-watchdog reboot (~once every few days) remains under investigation; no coredump captured. The frequent MQTT crashes fixed here were the dominant cause.

Full detail in the `[3.2.1]` section of `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)