### PR TITLE
fix: make Eco-Smart "Off" reachable/stable from Home Assistant (esm stays pegged)

### DIFF
--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1625,7 +1625,13 @@ void WallboxBLE::_pollSettings() {
     String r2 = _sendCommandDirect("g_ecos", "null", SETTINGS_TIMEOUT_MS);
     if (!r2.isEmpty()) {
         JsonDocument d; if (deserializeJson(d, r2) == DeserializationError::Ok) {
-            merged["eco_mode"] = d["r"]["esm"] | 0;
+            // Report "Off" whenever Eco-Smart is disabled (ese=0), regardless
+            // of the mode field. When the feature is turned off the charger
+            // firmware leaves `esm` pegged at its last value (e.g. 2), so
+            // publishing raw `esm` makes Home Assistant show a phantom
+            // "Solar + Grid"/"Full Green" that bounces back on every attempt to
+            // select Off. Gate the reported mode on the master enable flag.
+            merged["eco_mode"] = (d["r"]["ese"] | 0) ? (d["r"]["esm"] | 0) : 0;
             merged["eco_power"] = d["r"]["esp"] | 100;
         }
     }

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -702,8 +702,19 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
         int mode = 0;
         if (s.startsWith("Full Green")) mode = 1;
         else if (s == "Solar + Grid") mode = 2;
-        String p = "{\"esm\":" + String(mode) + ",\"ese\":" + String(mode > 0 ? 1 : 0) + ",\"esp\":100}";
-        wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, p.c_str());
+        if (mode == 0) {
+            // Disabling: the charger ignores an `esm` change that arrives
+            // together with ese=0, leaving `esm` stuck at its previous value
+            // (which then reads back as a phantom mode). Send the mode change
+            // first with the master flag still ON so it is accepted, then drop
+            // the flag — this clears `esm` and leaves the charger at
+            // {ese:0, esm:0}.
+            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, "{\"esm\":0,\"ese\":1,\"esp\":100}");
+            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, "{\"esm\":0,\"ese\":0,\"esp\":100}");
+        } else {
+            String p = "{\"esm\":" + String(mode) + ",\"ese\":1,\"esp\":100}";
+            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, p.c_str());
+        }
 
     } else if (sub == "eco_power") {
         int pct = atoi(payload);


### PR DESCRIPTION
Fixes #29.

The `eco_mode` select (and the "Solar charging" switch) cannot be set to **Off** from Home Assistant — it bounces back to the previous mode. Two independent causes, both fixed here.

### 1. Read-back ignored `ese` (`src/wb_ble.cpp`)

`g_ecos` returns `ese` (master enable) + `esm` (mode). When Eco-Smart is off, the charger leaves `esm` pegged at its last value (e.g. `2`) and only clears `ese`. Publishing raw `esm` made HA show a phantom "Solar + Grid".

```diff
-            merged["eco_mode"] = d["r"]["esm"] | 0;
+            merged["eco_mode"] = (d["r"]["ese"] | 0) ? (d["r"]["esm"] | 0) : 0;
```

### 2. Disabling write was self-defeating (`src/wb_mqtt.cpp`)

Selecting "Off" sent `{esm:0, ese:0}` in one shot; the charger ignores an `esm` change that arrives together with `ese:0`, so `esm` never cleared. Now disabling does a two-step write (mode change first with the flag still on, then drop the flag), mirroring the known-good manual BAPI workaround.

### Testing

Pulsar MAX Pro, charger FW 6.11.25, gateway v3.2.1:

- Before: selecting **Off** in HA → select snaps back to "Solar + Grid"; `g_ecos` = `{"ese":0,"esm":2}`.
- After: selecting **Off** → `g_ecos` = `{"ese":0,"esm":0}`, HA select stays on **Off**, no bounce.
- Selecting Full Green / Solar + Grid still works (unchanged `ese:1` path).

Changes are limited to the two mode paths; `eco_power` and every other control are untouched.
