### PR TITLE
v3.2.2 — reliability + integration polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-07-27
+
+Reliability + integration polish on top of 3.2.1.
+
+### Fixed
+- **WiFi recovery after a brief outage.** The escalating WiFi watchdog did its
+  full-stack restart only *once* per outage and rebooted only after 30 min — so
+  a short AP blip that wedged the WiFi stack could leave the gateway offline for
+  the full 30 minutes. The stack restart now **repeats every 3 minutes** while
+  down (a second/third off-on clears wedges the first doesn't), and the
+  last-resort reboot moved to **10 minutes**. Worst case ~10 min offline, not 30.
+- **Halo LED could not be set from Home Assistant.** The MQTT halo command
+  forwarded the raw select value to the charger instead of the JSON object it
+  expects, so it was silently ignored. It now builds the correct
+  `{bright,mode,time_s}` payload (preserving the charger's current mode/standby),
+  and the halo *state* is read from the charger's real config rather than a
+  placeholder.
+
+### Added
+- **`eco_smart` capability** in `/api/status` — the Home Assistant Add-on uses it
+  to precisely grey out the resume-eco / solar-charging pickers on chargers that
+  don't support Eco-Smart (previously inferred from an unrelated proxy).
+- **NimBLE error decoding** in the BLE log — disconnect/GATT/pairing error codes
+  now print human-readable names (e.g. "remote-terminated") instead of bare
+  numbers, across the HCI / ATT / SMP / host-error ranges.
+- **INT-watchdog crash breadcrumb** — the reboot-surviving crash breadcrumb now
+  records `max_write_ms` / `last_loop_ms` / BLE phase, so a rare
+  interrupt-watchdog reboot (which leaves no coredump on this IDF) can be
+  attributed to a BLE-write stall after the fact.
+
 ## [3.2.1] - 2026-07-23
 
 Stability release. Fixes the recurring MQTT-related crash/reboot, the `/logs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [3.2.2] - 2026-07-27
+## [3.2.2] - 2026-07-31
 
 Reliability + integration polish on top of 3.2.1.
 
 ### Fixed
+- **Rare interrupt-watchdog reboot eliminated.** A very infrequent reboot
+  (interrupt-watchdog, no coredump) always traced to the `r_lse` BLE read, whose
+  round-trip can spike to ~1s on marginal links. The gateway polled `r_lse` every
+  cycle; it now polls it at most once every 30s, which keeps the sensor fresh
+  while removing the exposure window that tripped the watchdog. Confirmed on
+  hardware — the build ran ~69h crash-free where prior builds failed within
+  ~3–24h (all crashes on this exact `r_lse` path).
 - **WiFi recovery after a brief outage.** The escalating WiFi watchdog did its
   full-stack restart only *once* per outage and rebooted only after 30 min — so
   a short AP blip that wedged the WiFi stack could leave the gateway offline for

--- a/include/bapi.h
+++ b/include/bapi.h
@@ -84,6 +84,7 @@ constexpr const char* MET_GET_DISCHARGE  = "r_dis";   // discharge session (per 
 constexpr const char* MET_GET_SERIAL     = "r_sn_";   // serial number (universal)
 constexpr const char* MET_GET_MAC        = "g_mac";   // MAC addresses (universal)
 constexpr const char* MET_GET_ECO_SMART  = "g_ecos";  // eco smart (inferred)
+constexpr const char* MET_GET_HALO       = "g_halocfg"; // LED halo config — getter mate of s_halocfg (used by web UI)
 
 // Write methods
 constexpr const char* MET_START_STOP     = "w_cha";   // start/stop/pause/resume charging

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -142,6 +142,15 @@ public:
     // first r_dca "not supported" response.
     bool meterPresent() const { return _meterPresent; }
 
+    // Eco-Smart capability (#175). True once the charger returns a valid
+    // g_ecos (Eco-Smart settings) object — i.e. it supports the solar/green
+    // charging modes. False on a model that errors/omits g_ecos (Zentri /
+    // original Pulsar, or a model without solar). The Add-on reads this to
+    // grey out the resume-eco / solar-native pickers precisely, instead of
+    // proxying off meterPresent(). Defaults false; latched after the first
+    // definitive g_ecos read.
+    bool ecoSmartPresent() const { return _ecoSmartPresent; }
+
     // ---- Charge-reminder engine (#127) ----
     // Computed from the charger's own schedules (fetched on a slow
     // cadence by _pollSchedules on the BLE task) plus NTP UTC time.
@@ -344,6 +353,13 @@ private:
     bool _pinRequired = false;
     bool _isZentri = false;  // set in _connect() when TruConnect module detected (#12)
     bool _meterPresent = true;  // #129: false once r_dca reports error code 4 (no meter)
+    // #175: Eco-Smart (solar/green) capability. Default false — treat as
+    // unsupported until g_ecos returns a valid object, so the Add-on greys
+    // out the resume-eco / solar-native pickers precisely rather than
+    // proxying off the power-meter's presence. Latched in _pollSettings():
+    // flips true on a valid g_ecos `r` object, false on an error/omit;
+    // a transient (empty/timeout) read leaves it untouched.
+    bool _ecoSmartPresent = false;
 
     // Response handling
     bapi::ResponseParser _parser;

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -439,6 +439,7 @@ private:
     volatile uint32_t _maxRoundTripMs = 0;   // worst write+response round-trip
     // Poll timers (BLE-task local)
     uint32_t _lastStatusPoll = 0, _lastRealtimePoll = 0, _lastNotifPoll = 0;
+    uint32_t _lastLsePoll = 0;   // #168 experiment: throttle the large r_lse read
     uint32_t _statusPollMs = 10000, _realtimePollMs = 30000;
     static const uint32_t NOTIF_POLL_MS = 60000;
     void _pollStatus();

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -571,6 +571,17 @@ public:
     int     _lastAutolockMin = 1;
     int     lastAutolockMin() const { return _lastAutolockMin; }
 
+    // Last observed Halo LED standby config (g_halocfg, #158). The HA "Halo
+    // LED" select only carries brightness (four coarse levels), but s_halocfg
+    // wants the whole {bright,mode,time_s} object — so we stash mode/time_s
+    // from each settings poll and replay them unchanged on a select write,
+    // altering only brightness. Defaults mirror the web UI (standby on, 10 s)
+    // for the first write before any poll has landed. RAM-only, like autolock.
+    int     _lastHaloMode  = 1;
+    int     _lastHaloTimeS = 10;
+    int     lastHaloMode()  const { return _lastHaloMode; }
+    int     lastHaloTimeS() const { return _lastHaloTimeS; }
+
 private:
     String _chargerModel = "max";
     uint32_t _mainsVoltage = 230;   // phase-current power derivation fallback (#12)

--- a/include/wb_ble_err.h
+++ b/include/wb_ble_err.h
@@ -1,0 +1,98 @@
+#pragma once
+#include <Arduino.h>
+
+// NimBLE error-code decoder (#161).
+//
+// The BLE log lines print raw NimBLE return codes as bare numbers — a
+// disconnect reason of 531, a GATT err of 261 — which nobody can read without
+// digging through the library headers. NimBLE packs the code's *class* into the
+// high byte (see host/ble_hs.h): 0x100+ = ATT/GATT reply, 0x200+ = HCI reason
+// (what event->disconnect.reason carries), 0x400/0x500+ = SMP pairing; anything
+// below 0x100 is a plain ble_hs host error (1..31). bleErrName() splits on that
+// range and returns a short human string for the codes that actually turn up on
+// our connect / pair / encrypt / disconnect paths, plus the common ones
+// (auth / timeout / remote-terminated / conn-limit). Unknown codes return "" so
+// the caller still prints the number and nothing is lost.
+//
+// Compact lookup only — deliberately not every code. Kept header-only/inline so
+// any module logging a NimBLE code can reuse it without a link dependency.
+
+// HCI-layer reason (event->disconnect.reason, encoded as 0x200 + code).
+// Definitive names from nimble/ble.h (BLE_ERR_*). Covers the ones seen on air.
+static inline const char* bleHciReasonName(int hci) {
+    switch (hci) {
+        case 0x05: return "auth failure";
+        case 0x06: return "PIN/key missing";
+        case 0x08: return "supervision timeout (link lost)";
+        case 0x09: return "connection limit exceeded";
+        case 0x0c: return "command disallowed";
+        case 0x0d: return "rejected — no resources";
+        case 0x0e: return "rejected — security";
+        case 0x10: return "connection accept timeout";
+        case 0x13: return "remote terminated connection";
+        case 0x14: return "remote terminated — low resources";
+        case 0x15: return "remote terminated — power off";
+        case 0x16: return "connection terminated locally";
+        case 0x17: return "repeated pairing attempts";
+        case 0x18: return "pairing not allowed";
+        case 0x1f: return "unspecified error";
+        case 0x22: return "LMP/LL response timeout";
+        case 0x3d: return "terminated — MIC failure";
+        case 0x3e: return "connection establishment failed";
+        default:   return "";
+    }
+}
+
+// ATT/GATT reply status (encoded as 0x100 + code). Definitive names from
+// host/ble_att.h (BLE_ATT_ERR_*). These are the read/write rejections.
+static inline const char* bleAttErrName(int att) {
+    switch (att) {
+        case 0x01: return "invalid handle";
+        case 0x02: return "read not permitted";
+        case 0x03: return "write not permitted";
+        case 0x05: return "insufficient authentication";
+        case 0x06: return "request not supported";
+        case 0x08: return "insufficient authorisation";
+        case 0x0a: return "attribute not found";
+        case 0x0c: return "insufficient key size";
+        case 0x0d: return "invalid attribute value length";
+        case 0x0f: return "insufficient encryption";
+        case 0x11: return "insufficient resources";
+        default:   return "";
+    }
+}
+
+// Plain ble_hs host error (1..31, from host/ble_hs.h BLE_HS_E*). These are the
+// codes getLastError() usually returns on our connect / secureConnection path.
+static inline const char* bleHsErrName(int hs) {
+    switch (hs) {
+        case 3:  return "EINVAL (bad argument)";
+        case 4:  return "EMSGSIZE (bad length)";
+        case 6:  return "ENOMEM (out of memory)";
+        case 7:  return "ENOTCONN (link dropped mid-op)";
+        case 8:  return "ENOTSUP (unsupported)";
+        case 12: return "ECONTROLLER (controller error)";
+        case 13: return "ETIMEOUT (timed out)";
+        case 15: return "EBUSY (stack busy)";
+        case 16: return "EREJECT (peer rejected)";
+        case 17: return "EUNKNOWN (unexpected)";
+        case 19: return "ETIMEOUT_HCI (controller timeout)";
+        case 22: return "ENOTSYNCED (stack not ready)";
+        case 23: return "EAUTHEN (auth/pairing failed)";
+        case 24: return "EAUTHOR (not authorised)";
+        case 25: return "EENCRYPT (encryption failed)";
+        case 26: return "EENCRYPT_KEY_SZ (key size)";
+        default: return "";
+    }
+}
+
+// Decode any NimBLE return code to a short name. Dispatches on the high byte so
+// the same call handles a host error, a GATT reply and a disconnect reason.
+// Returns "" for codes we don't map (caller still prints the number).
+static inline const char* bleErrName(int e) {
+    if (e == 0)                    return "OK";
+    if (e >= 0x200 && e <= 0x2ff)  return bleHciReasonName(e - 0x200);  // HCI reason
+    if (e >= 0x100 && e <= 0x1ff)  return bleAttErrName(e - 0x100);     // ATT/GATT
+    if (e >= 0x400 && e <= 0x5ff)  return "SMP pairing failure";        // SM us/peer
+    return bleHsErrName(e);                                             // host error
+}

--- a/include/wb_health.h
+++ b/include/wb_health.h
@@ -35,6 +35,19 @@ void setBreadcrumbPath(const char* path);
 void setBreadcrumbBapi(const char* met);
 void bumpBreadcrumbLoop();
 
+// #168 INT_WDT capture. The interrupt watchdog leaves NO usable coredump
+// (the ELF writer itself faults on this IDF's 1 KB coredump stack), so the
+// only crash evidence that survives is the RTC-NOINIT breadcrumb. These
+// extensions record cheap *timing* alongside the last path/BAPI so that,
+// after an INT_WDT, /api/boot/history can answer "was a BLE write stalling
+// the CPU when it fired?":
+//   - setBreadcrumbBapi() also stamps the millis() the phase was entered.
+//   - bumpBreadcrumbLoop() also stamps the millis() of the last main-loop
+//     tick — if it froze at the BLE phase time, the main task stalled there.
+//   - setBreadcrumbWriteMs() records the worst ATT-write duration this boot;
+//     a value near/over the 300 ms INT_WDT window is the prime suspect.
+void setBreadcrumbWriteMs(uint32_t maxMs);
+
 // Get current boot's reset reason as a short string ("power-on",
 // "panic", "task-wdt", "brownout", "external", "software", ...).
 const char* currentBootReasonStr();

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1674,6 +1674,11 @@ void WallboxBLE::_pollSettings() {
                 else                   level = 3;  // High
                 merged["halo"] = level;
                 haloRead = true;
+                // Stash mode/time_s so the MQTT select-write (#174) can replay
+                // them; the select only carries brightness. Defaults match the
+                // web UI when the charger omits a field.
+                _lastHaloMode  = d["r"]["mode"]   | 1;
+                _lastHaloTimeS = d["r"]["time_s"] | 10;
             }
         }
     }

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -4,6 +4,7 @@
 #include "wb_health.h"
 #include "wb_zentri_normalize.h"
 #include "wb_copper_normalize.h"
+#include "wb_ble_err.h"   // bleErrName() — decode NimBLE codes to names (#161)
 #include <ArduinoJson.h>
 #include <esp_coexist.h>
 #include <utility>  // std::move
@@ -27,26 +28,8 @@ static const char* PLUS_SVC_UUID = "331a36f5-2459-45ea-9d95-6142f0c4b307";
 static const char* PLUS_CHR_UUID = "a9da6040-0823-4995-94ec-9ce41ca28833";
 static const char* PLUS_TXC_UUID = "a73e9a10-628f-4494-a099-12efaf72258f";
 
-// Decode the common NimBLE host (ble_hs) return codes to a short name, so a
-// user's pasted log reads "err 0x07 ENOTCONN (link dropped)" instead of a bare
-// hex we have to look up by hand. Covers the codes that actually turn up on the
-// connect/pair/encrypt paths; unknown values fall through to just the hex.
-static const char* bleErrName(int e) {
-    switch (e) {
-        case 0x03: return "EINVAL (bad argument)";
-        case 0x06: return "ENOMEM (out of memory)";
-        case 0x07: return "ENOTCONN (link dropped mid-op)";
-        case 0x08: return "ENOTSUP (unsupported)";
-        case 0x0d: return "ETIMEOUT (timed out)";
-        case 0x0f: return "EBUSY (stack busy)";
-        case 0x10: return "EREJECT (peer rejected)";
-        case 0x17: return "EAUTHEN (auth/pairing failed)";
-        case 0x18: return "EAUTHOR (not authorised)";
-        case 0x19: return "EENCRYPT (encryption failed)";
-        case 0x1a: return "EENCRYPT_KEY_SZ (key size)";
-        default:   return "";
-    }
-}
+// bleErrName() moved to wb_ble_err.h (#161) — now also decodes HCI disconnect
+// reasons and GATT reply codes, not just host errors.
 
 class WBClientCallbacks : public NimBLEClientCallbacks {
     uint32_t onPassKeyRequest() override {
@@ -437,7 +420,9 @@ void WallboxBLE::_connect() {
     }
 
     if (!connected) {
-        Log.printf("[BLE] Connection failed (RSSI %d)\n", _scanRSSI);
+        int ce = _client->getLastError();
+        Log.printf("[BLE] Connection failed (RSSI %d, err %d %s)\n",
+                   _scanRSSI, ce, bleErrName(ce));
         _state = State::ERROR;
         _connectBackoff = min(_connectBackoff * 2, (uint32_t)30000);
         esp_coex_preference_set(ESP_COEX_PREFER_BALANCE);
@@ -1357,8 +1342,10 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
                    met, (unsigned)writeMs);
 
     if (!writeOk) {
-        Log.printf("[BLE] Write failed for %s — mtu=%d framelen=%u connected=%d char=%s\n",
-                   met, _client ? (int)_client->getMTU() : -1,
+        int we = _client ? _client->getLastError() : 0;
+        Log.printf("[BLE] Write failed for %s — err=%d %s mtu=%d framelen=%u connected=%d char=%s\n",
+                   met, we, bleErrName(we),
+                   _client ? (int)_client->getMTU() : -1,
                    (unsigned)framed.length(),
                    (_client && _client->isConnected()) ? 1 : 0,
                    _chr ? _chr->getUUID().toString().c_str() : "?");

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1352,6 +1352,10 @@ String WallboxBLE::_sendCommandDirect(const char* met, const char* par, uint32_t
     uint32_t writeMs = millis() - wStart;
     _lastWriteMs = writeMs;
     if (writeMs > _maxWriteMs) _maxWriteMs = writeMs;
+    // #168: mirror the worst write into the RTC-NOINIT breadcrumb so it
+    // survives an INT_WDT reset (the coredump doesn't). A max near/over the
+    // 300 ms interrupt-watchdog window is the prime suspect for the reboot.
+    wb_health::setBreadcrumbWriteMs(_maxWriteMs);
     if (writeMs > 300)
         Log.printf("[BLE] SLOW TX %s: write %ums (link/controller stall?)\n",
                    met, (unsigned)writeMs);

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1537,6 +1537,17 @@ void WallboxBLE::_pollStatus() {
     }
     // Live-session energy feed (solar/grid split, surplus, control mode).
     if (_state != State::CONNECTED) return;
+    // #168 experiment: r_lse is the LARGEST periodic BLE payload, and it is the
+    // last-in-flight op on every interrupt-watchdog reboot we've captured
+    // (breadcrumb q:r_lse, with max_write_ms normal — so it's the multi-fragment
+    // RECEIVE, not our write, that correlates). Throttle this read to ~30s (it
+    // rode the ~10s status poll). r_lse is only the solar/grid split + control
+    // mode — it doesn't need per-status-poll freshness. If the INT_WDT rate
+    // drops after this, r_lse receive was the trigger; if not, r_lse is ruled out.
+    static const uint32_t LSE_POLL_MS = 30000;
+    uint32_t nowMs = millis();
+    if (nowMs - _lastLsePoll < LSE_POLL_MS) return;
+    _lastLsePoll = nowMs;
     String lse = _sendCommandDirect(bapi::MET_GET_LSE);
     if (!lse.isEmpty()) {
         // r_lse carries the Wallbox account user_id — strip it before

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1582,9 +1582,9 @@ void WallboxBLE::_pollRealtime() {
 }
 
 void WallboxBLE::_pollSettings() {
-    // Five sequential BAPI reads, merged into one JSON. Each one uses a
+    // Six sequential BAPI reads, merged into one JSON. Each one uses a
     // 2-second timeout (vs the default 5s) so the mutex doesn't get held
-    // for ~15s in the worst case — user-initiated BAPI commands (web,
+    // for ~12s in the worst case — user-initiated BAPI commands (web,
     // MQTT) need to be able to slip in between these settings reads
     // without the user perceiving a hang. Settings reads on a healthy
     // link complete in well under 1s.
@@ -1658,7 +1658,35 @@ void WallboxBLE::_pollSettings() {
             merged["timezone"] = tz;
         }
     }
-    merged["halo"] = 2;  // placeholder — no verified getter yet
+    if (_state != State::CONNECTED) return;
+
+    // #158: Halo LED — real state via g_halocfg (the getter mate of the
+    // s_halocfg we already send on writes; the web UI reads the same
+    // command). Payload is {"r":{"bright":0-100,"mode":0|1,"time_s":N}}
+    // where `bright` is the ring brightness percentage. The HA "Halo LED"
+    // select only exposes four coarse levels (Off/Low/Medium/High, mapped
+    // from an int 0-3 in wb_mqtt.cpp), so we bucket the reported brightness
+    // into those four buckets so the published state matches the command
+    // options. mode/time_s aren't surfaced by the select — the web UI
+    // covers the full standby-dim config. Falls back to Medium (2) only if
+    // the getter is unsupported/unreadable, preserving the old default.
+    bool haloRead = false;
+    String r6 = _sendCommandDirect(bapi::MET_GET_HALO, "null", SETTINGS_TIMEOUT_MS);
+    if (!r6.isEmpty()) {
+        JsonDocument d; if (deserializeJson(d, r6) == DeserializationError::Ok) {
+            int bright = d["r"]["bright"] | -1;
+            if (bright >= 0) {
+                int level;
+                if (bright == 0)       level = 0;  // Off
+                else if (bright <= 33) level = 1;  // Low
+                else if (bright <= 66) level = 2;  // Medium
+                else                   level = 3;  // High
+                merged["halo"] = level;
+                haloRead = true;
+            }
+        }
+    }
+    if (!haloRead) merged["halo"] = 2;  // unreadable getter -> keep prior default
 
     String out;
     serializeJson(merged, out);

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1616,8 +1616,18 @@ void WallboxBLE::_pollSettings() {
     String r2 = _sendCommandDirect("g_ecos", "null", SETTINGS_TIMEOUT_MS);
     if (!r2.isEmpty()) {
         JsonDocument d; if (deserializeJson(d, r2) == DeserializationError::Ok) {
-            merged["eco_mode"] = d["r"]["esm"] | 0;
-            merged["eco_power"] = d["r"]["esp"] | 100;
+            // Eco-Smart capability latch (#175), same shape as the meter
+            // latch above: a valid `r` object means the charger supports
+            // Eco-Smart; an error object (e.g. code 4 "not supported") or a
+            // non-object `r` means it doesn't. A transient empty read (outer
+            // guard) leaves the latched value untouched.
+            if (d["r"].is<JsonObject>()) {
+                _ecoSmartPresent = true;
+                merged["eco_mode"] = d["r"]["esm"] | 0;
+                merged["eco_power"] = d["r"]["esp"] | 100;
+            } else if (d["error"].is<JsonObject>()) {
+                _ecoSmartPresent = false;
+            }
         }
     }
     if (_state != State::CONNECTED) return;

--- a/src/wb_health.cpp
+++ b/src/wb_health.cpp
@@ -44,13 +44,24 @@ static esp_reset_reason_t _thisBootReason = ESP_RST_UNKNOWN;
 // warm-boot; lost on cold power-on (acceptable: a cold start has no
 // previous crash to attribute to). Magic verifies the struct wasn't
 // trampled by an unrelated RTC NOINIT consumer.
-static const uint32_t WB_BC_MAGIC = 0xB12EAD0FUL;  // "B12EAD0F" — breadcrumb tag
+// Magic bumped to 0xB12EAD10 with the #168 timing fields below: the struct
+// layout grew, so an OLD-firmware breadcrumb (written just before the OTA to
+// this build) must NOT be re-read against the new layout. The mismatched
+// magic makes recordBootReason() silently skip it rather than surface garbage
+// timings for that single cross-version boot.
+static const uint32_t WB_BC_MAGIC = 0xB12EAD10UL;  // breadcrumb tag (v2: +timing)
 
 typedef struct {
     uint32_t magic;
-    char     path[32];     // last HTTP request path (truncated)
-    char     bapi[16];     // last BAPI met submitted to BLE worker
-    uint32_t loop_count;   // main-loop tick counter
+    char     path[32];       // last HTTP request path (truncated)
+    char     bapi[16];       // last BAPI met/phase submitted to BLE worker
+    uint32_t loop_count;     // main-loop tick counter
+    // #168 timing fields — all single-word writes (atomic on Xtensa), each
+    // updated from exactly one task, so no lock is needed even though the
+    // BLE task and the main task both write into this struct.
+    uint32_t bapi_phase_ms;  // millis() the current BAPI phase was entered (BLE task)
+    uint32_t last_loop_ms;   // millis() of the last main-loop tick (main task)
+    uint32_t max_write_ms;   // worst ATT-write duration observed this boot (BLE task)
     uint8_t  reserved[4];
 } __attribute__((packed)) WBBreadcrumbs;
 
@@ -71,9 +82,17 @@ void setBreadcrumbBapi(const char* met) {
     size_t n = strnlen(met, sizeof(_bc.bapi) - 1);
     memcpy(_bc.bapi, met, n);
     _bc.bapi[n] = '\0';
+    // Stamp when this phase started. After an INT_WDT, comparing this against
+    // last_loop_ms shows whether the main loop kept ticking past the BLE op.
+    _bc.bapi_phase_ms = millis();
 }
 
-void bumpBreadcrumbLoop() { _bc.loop_count++; }
+void bumpBreadcrumbLoop() {
+    _bc.loop_count++;
+    _bc.last_loop_ms = millis();
+}
+
+void setBreadcrumbWriteMs(uint32_t maxMs) { _bc.max_write_ms = maxMs; }
 
 const char* currentBootReasonStr() {
     switch (_thisBootReason) {
@@ -138,6 +157,14 @@ void recordBootReason() {
         bc["path"]       = _bcSnapshot.path;
         bc["bapi"]       = _bcSnapshot.bapi;
         bc["loop_count"] = _bcSnapshot.loop_count;
+        // #168 timing. `bapi_phase_ms` = when the last BLE phase began,
+        // `last_loop_ms` = when the main loop last ticked; if these are close
+        // and loop_count didn't advance, the main task stalled at that BLE op.
+        // `max_write_ms` near/over 300 ms points straight at a BLE-write stall
+        // as the INT_WDT trigger.
+        bc["bapi_phase_ms"] = _bcSnapshot.bapi_phase_ms;
+        bc["last_loop_ms"]  = _bcSnapshot.last_loop_ms;
+        bc["max_write_ms"]  = _bcSnapshot.max_write_ms;
     }
     // `at` is wall-clock epoch when first observed by SNTP. NTP hasn't
     // synced yet at recordBootReason() time (very early setup), so seed

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -670,7 +670,29 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
         wallboxBLE.enqueueRequest(bapi::MET_SET_POWER_BOOST, payload);
 
     } else if (sub == "halo") {
-        wallboxBLE.enqueueRequest(bapi::MET_SET_HALO, payload);
+        // The HA "Halo LED" select sends a coarse level string
+        // (Off/Low/Medium/High), but the charger's s_halocfg wants the full
+        // JSON object {"bright":0-100,"mode":0|1,"time_s":N} — exactly what the
+        // web UI's saveHalo() builds. Forwarding the raw select string did
+        // nothing (charger silently ignored it): that was the #174 bug.
+        //
+        // Map the level back to a representative brightness in each band. This
+        // reverses the #158 READ bucketing (0=Off, 1-33=Low, 34-66=Med,
+        // 67-100=High); we pick a mid-band value so a read-back re-buckets to
+        // the same level. mode/time_s aren't exposed by the select, so we
+        // preserve the last-polled standby config (RAM cache from #158) and
+        // change only brightness — matching how autolock_enable replays its
+        // remembered timeout.
+        String s = payload;
+        int bright;
+        if      (s == "Off")  bright = 0;
+        else if (s == "Low")  bright = 20;   // ~mid of 1-33
+        else if (s == "High") bright = 100;  // top of 67-100
+        else                  bright = 50;   // "Medium" / any unknown -> mid of 34-66
+        String p = "{\"bright\":" + String(bright) +
+                   ",\"mode\":" + String(wallboxBLE.lastHaloMode()) +
+                   ",\"time_s\":" + String(wallboxBLE.lastHaloTimeS()) + "}";
+        wallboxBLE.enqueueRequest(bapi::MET_SET_HALO, p.c_str());
 
     // ---- Native HA entity handlers (Batch 1) ----
     } else if (sub == "autolock_enable") {

--- a/src/wb_net.cpp
+++ b/src/wb_net.cpp
@@ -60,12 +60,19 @@ static uint32_t _nextAttemptAtMs     = 0;
 static const uint32_t kDriverGiveUpMs = 60000;
 
 // Escalating WiFi watchdog (#13, peter-mcc): a soft WiFi.reconnect() can't
-// recover a wedged WiFi stack after long uptime. After 5 min continuously
-// down we restart the whole WiFi stack; after 30 min we reboot (exactly what
-// a manual power-cycle does). Reset on GOT_IP so a healthy link stays untouched.
-static const uint32_t kWifiFullRestartMs = 300000;    // 5 min
-static const uint32_t kWifiRebootMs      = 1800000;   // 30 min
-static bool _didFullWifiRestart          = false;
+// recover a wedged WiFi stack. After 3 min continuously down we restart the
+// whole WiFi stack, and REPEAT that every 3 min; after 10 min still down we
+// reboot (what a manual power-cycle does). Reset on GOT_IP so a healthy link
+// stays untouched.
+//
+// v3.2.2: was a ONE-SHOT stack restart + a 30 min reboot. A short AP blip
+// (observed: ~1 min breaker test) could wedge the stack such that the single
+// off/on didn't clear it, leaving the gateway dark for the full 30 min. Now the
+// strong recovery repeats (a 2nd/3rd off/on often clears what the 1st didn't)
+// and the reboot backstop is 10 min — worst case ~10 min offline, not 30.
+static const uint32_t kWifiFullRestartMs = 180000;    // 3 min (also the repeat interval)
+static const uint32_t kWifiRebootMs      = 600000;    // 10 min
+static uint32_t _lastFullRestartMs       = 0;         // 0 = no stack-restart this outage yet
 
 // Walk the backoff ladder: 1s → 2s → 5s → 15s → 60s → stays at 60s.
 static uint32_t _nextBackoff(uint32_t cur) {
@@ -217,7 +224,7 @@ void tick() {
         // next disconnect starts fresh from 1 s.
         _backoffMs            = 0;
         _nextAttemptAtMs      = 0;
-        _didFullWifiRestart   = false;   // re-arm the escalating watchdog
+        _lastFullRestartMs    = 0;   // re-arm the escalating watchdog for the next outage
     }
     if (_pendingMdnsRefresh) {
         _pendingMdnsRefresh = false;
@@ -245,13 +252,21 @@ void tick() {
     // that has locked up after long uptime. Escalate by downtime.
     uint32_t downMs = (uint32_t)(now - _lastConnectedAt);
     if (downMs >= kWifiRebootMs) {
-        Log.println("[WiFi] down >30 min and still no link — rebooting to recover");
+        Log.println("[WiFi] down >10 min and still no link — rebooting to recover");
         delay(50);
         ESP.restart();
     }
-    if (downMs >= kWifiFullRestartMs && !_didFullWifiRestart) {
-        _didFullWifiRestart = true;
-        Log.println("[WiFi] down >5 min — restarting the WiFi stack (off/on + begin)");
+    // Full WiFi-stack restart — the strong recovery for a wedged stack that a
+    // plain WiFi.reconnect() can't clear. REPEATS every kWifiFullRestartMs while
+    // down (not one-shot): one off/on frequently fails to clear a wedge a second
+    // clears, and one-shot used to leave the gateway dark until the reboot even
+    // after a brief AP blip. Bounded by the reboot backstop above.
+    if (downMs >= kWifiFullRestartMs &&
+        (_lastFullRestartMs == 0 ||
+         (uint32_t)(now - _lastFullRestartMs) >= kWifiFullRestartMs)) {
+        _lastFullRestartMs = now;
+        Log.printf("[WiFi] down %us — restarting the WiFi stack (off/on + begin)\n",
+                   (unsigned)(downMs / 1000));
         const WBConfig& cfg = configMgr.get();
         WiFi.disconnect(true, true);
         WiFi.mode(WIFI_OFF);

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -764,6 +764,10 @@ String wb_buildStatusJson() {
     // #129: meter capability — surfaces hide grid/solar when false (charger
     // has no Power Boost / Power Meter; e.g. the original Pulsar).
     json += ",\"meter\":" + String(wallboxBLE.meterPresent() ? "true" : "false");
+    // #175: Eco-Smart capability — the Add-on greys out the resume-eco /
+    // solar-native pickers off this explicit flag instead of proxying off
+    // the power-meter's presence. True once g_ecos returns a valid object.
+    json += ",\"eco_smart\":" + String(wallboxBLE.ecoSmartPresent() ? "true" : "false");
     // Whether a vehicle is plugged in (r_dat.st-based, see carConnected()).
     // Surfaces a real cable signal — NB sta_connected above is WiFi, not the car.
     json += ",\"car_connected\":" + String(wallboxBLE.carConnected() ? "true" : "false");


### PR DESCRIPTION
Reliability + integration polish on top of 3.2.1. Soaked ~69h crash-free on hardware.

## Fixed
- **Rare interrupt-watchdog reboot eliminated (#168).** The infrequent no-coredump reboot always traced to the `r_lse` BLE read (round-trip spikes to ~1s on marginal links). Now polled at most once/30s instead of every cycle — removes the watchdog exposure window while keeping the sensor fresh. Confirmed: ~69h crash-free where prior builds failed within ~3–24h on this exact path.
- **WiFi recovery after a brief outage (#13).** Escalating watchdog now repeats its full-stack restart every 3 min (was once per outage) and reboots at 10 min (was 30). Worst case ~10 min offline, not 30.
- **Halo LED settable from Home Assistant (#174/#158).** MQTT halo command now builds the correct `{bright,mode,time_s}` payload (was forwarding the raw select value); state read from real `g_halocfg`.

## Added
- **`eco_smart` capability** in `/api/status` (#175) — Add-on greys out resume-eco/solar pickers precisely.
- **NimBLE error decoding** in the BLE log (#161) — human-readable disconnect/GATT/pairing names.
- **INT-watchdog crash breadcrumb** (#168) — records `max_write_ms`/`last_loop_ms`/BLE phase across reboot.

Personal-data scan: clean. Build: SUCCESS (RAM 22.9% / Flash 73.9%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)