### PR TITLE
v3.2.4 — Pulsar Plus (Max BLE stack) Stop + live lock + product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [3.2.3] - 2026-08-01
+## [3.2.4] - 2026-08-09
+
+Fixes for a Pulsar Plus that speaks the Max-family (single-char) BLE stack —
+e.g. units on the u-blox NINA-B22 (reported on the HA forum for
+`prj08-pulsar-plus-pm3`).
+
+### Fixed
+- **Stop charging works on a Pulsar Plus that rides the Max BLE stack.** The
+  `w_cha` stop parameter now follows the charger's own product (`chg_project` →
+  Plus `par=0` / Max `par=2`), not the BLE transport family the auto-switch
+  adopts. A Pulsar Plus is a Plus (`par=0`) even when it presents the Max
+  single-char service. Applied to both `/api/command` handlers (the async one
+  the gateway serves had been missed).
+- **Lock state tracks live.** The discrete lock state is refreshed from the
+  periodic `r_sta` poll instead of being read once at connect, so the HA "Lock
+  state" entity no longer freezes after a lock/unlock, and the gateway web
+  dashboard updates it over the WebSocket too (r_sta is now broadcast).
+- **HA device card shows the true product** from `chg_project` (e.g. "Pulsar
+  Plus"), not the BLE transport family.
+
+### Changed
+- The Stop action logs its decision (`chg_project` / model / `w_cha par`) to
+  aid future charger-specific debugging.
 
 ### Fixed
 - **Eco-Smart "Off" is now reachable from Home Assistant and the web UI (#29).**

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -316,15 +316,6 @@ public:
         return "";
     }
 
-    // Command-semantics model family (e.g. the w_cha stop parameter). Sourced
-    // from the charger's OWN project self-report (inferredModel), NOT the BLE
-    // transport family the auto-switch may have adopted: a Pulsar Plus that
-    // speaks the MAX single-char transport must still get Plus command
-    // semantics (stop par=0, which a Plus honours; par=2 it only ACKs and
-    // ignores). Falls back to the configured model until the project is read.
-    // Implemented in wb_ble.cpp (needs configMgr).
-    bool isPlusCommandFamily() const;
-
     // Firmware-change tracking — set when the GATT-reported FW differs
     // from the value persisted from the previous boot. Catches Wallbox
     // silent auto-OTAs that change behaviour overnight.

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -316,6 +316,15 @@ public:
         return "";
     }
 
+    // Command-semantics model family (e.g. the w_cha stop parameter). Sourced
+    // from the charger's OWN project self-report (inferredModel), NOT the BLE
+    // transport family the auto-switch may have adopted: a Pulsar Plus that
+    // speaks the MAX single-char transport must still get Plus command
+    // semantics (stop par=0, which a Plus honours; par=2 it only ACKs and
+    // ignores). Falls back to the configured model until the project is read.
+    // Implemented in wb_ble.cpp (needs configMgr).
+    bool isPlusCommandFamily() const;
+
     // Firmware-change tracking — set when the GATT-reported FW differs
     // from the value persisted from the previous boot. Catches Wallbox
     // silent auto-OTAs that change behaviour overnight.

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -320,7 +320,7 @@ public:
     // charger's OWN product (chg_project via inferredModel), NOT the BLE
     // transport the auto-switch adopted: a Pulsar Plus on the Max single-char
     // stack is still a Plus and needs par=0 (a Plus ACKs par=2 but ignores it —
-    // confirmed on Kenneth's prj08-pulsar-plus-pm3). Falls back to the
+    // confirmed on a prj08-pulsar-plus-pm3). Falls back to the
     // configured transport model until fw_v_ is read. Impl in wb_ble.cpp.
     bool isPlusCommandFamily() const;
 

--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -316,6 +316,14 @@ public:
         return "";
     }
 
+    // Command-semantics family for the w_cha stop parameter. Follows the
+    // charger's OWN product (chg_project via inferredModel), NOT the BLE
+    // transport the auto-switch adopted: a Pulsar Plus on the Max single-char
+    // stack is still a Plus and needs par=0 (a Plus ACKs par=2 but ignores it —
+    // confirmed on Kenneth's prj08-pulsar-plus-pm3). Falls back to the
+    // configured transport model until fw_v_ is read. Impl in wb_ble.cpp.
+    bool isPlusCommandFamily() const;
+
     // Firmware-change tracking — set when the GATT-reported FW differs
     // from the value persisted from the previous boot. Catches Wallbox
     // silent auto-OTAs that change behaviour overnight.

--- a/include/wb_config.h
+++ b/include/wb_config.h
@@ -98,15 +98,21 @@ public:
         return m == "plus" || m == "copper" || m == "quasar" || m == "quasar2";
     }
 
-    // Friendly product name for the configured model — shown in HA device card
-    // and elsewhere in the UI. Returns ("Wallbox <name>", "<name>") pair.
-    void productName(const char*& fullName, const char*& shortName) const {
-        const String& m = _cfg.chargerModel;
+    // Friendly product name for a model string. Pure mapping (string literals
+    // have static storage, so the const char* outputs stay valid).
+    static void productNameFor(const String& m, const char*& fullName, const char*& shortName) {
         if      (m == "plus")    { fullName = "Wallbox Pulsar Plus"; shortName = "Pulsar Plus"; }
         else if (m == "copper")  { fullName = "Wallbox Copper SB";   shortName = "Copper SB"; }
         else if (m == "quasar")  { fullName = "Wallbox Quasar";      shortName = "Quasar"; }
         else if (m == "quasar2") { fullName = "Wallbox Quasar 2";    shortName = "Quasar 2"; }
         else                     { fullName = "Wallbox Pulsar MAX";  shortName = "Pulsar MAX"; }
+    }
+
+    // Friendly product name for the configured (transport) model. Callers that
+    // want the true PRODUCT identity should map the charger's own chg_project
+    // via productNameFor() instead — see wb_mqtt populateDeviceBlock().
+    void productName(const char*& fullName, const char*& shortName) const {
+        productNameFor(_cfg.chargerModel, fullName, shortName);
     }
 
     // Reset all config to defaults

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,11 @@ static void publishCachedRealtimeIfNew() {
         _lastSeqRealtime = seq;
         lastRealtime = resp;
         webServer.updateCache(lastStatus, lastRealtime);   // always (see status drain, #20)
+        // Live-push r_sta so the dashboard's lock / OCPP fields update over the
+        // WebSocket too — when the WS is open the dashboard skips the /api/charger
+        // poll, so without this lock_status only refreshed on a full reload
+        // (forum: Kenneth — web UI lock state not updating).
+        wbws::broadcast("realtime", resp);
         if (wallboxMQTT.isConnected()) {
             wallboxMQTT.publishRealtime(resp);
             wallboxMQTT.publishCarConnected(lastStatus, lastRealtime);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ static void publishCachedRealtimeIfNew() {
         // Live-push r_sta so the dashboard's lock / OCPP fields update over the
         // WebSocket too — when the WS is open the dashboard skips the /api/charger
         // poll, so without this lock_status only refreshed on a full reload
-        // (forum: Kenneth — web UI lock state not updating).
+        // (forum report: web UI lock state not updating).
         wbws::broadcast("realtime", resp);
         if (wallboxMQTT.isConnected()) {
             wallboxMQTT.publishRealtime(resp);

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1896,6 +1896,17 @@ bool WallboxBLE::isCharging() {
     return false;
 }
 
+bool WallboxBLE::isPlusCommandFamily() const {
+    // Prefer the charger's own project self-report over the (possibly
+    // transport-clobbered) configured model. A Pulsar Plus on the MAX
+    // single-char BLE transport auto-switches cfg.chargerModel to "max", but
+    // its w_cha stop still needs the Plus parameter (par=0). See wb_web stop.
+    const String m = inferredModel();   // from _chgProject (fw_v_.p), "" if unknown
+    if (m.length())
+        return m == "plus" || m == "copper" || m == "quasar" || m == "quasar2";
+    return configMgr.isPlusFamily();    // project not read yet → configured model
+}
+
 bool WallboxBLE::startStopRedundant(bool wantStart) {
     // A "start" while already charging, or a "stop" while already stopped, is a
     // redundant w_cha write. Harmless on most chargers, but some (e.g. Pulsar

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1909,6 +1909,16 @@ bool WallboxBLE::isCharging() {
     return false;
 }
 
+bool WallboxBLE::isPlusCommandFamily() const {
+    // Product identity from the charger's own chg_project self-report — the
+    // same source the HA device card uses. A Pulsar Plus reports par=0 stop
+    // semantics regardless of whether it rides the Max single-char transport.
+    const String m = inferredModel();   // "plus"/"max"/... from _chgProject, "" if unread
+    if (m.length())
+        return m == "plus" || m == "copper" || m == "quasar" || m == "quasar2";
+    return configMgr.isPlusFamily();    // project not read yet → configured model
+}
+
 bool WallboxBLE::startStopRedundant(bool wantStart) {
     // A "start" while already charging, or a "stop" while already stopped, is a
     // redundant w_cha write. Harmless on most chargers, but some (e.g. Pulsar

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1580,7 +1580,20 @@ void WallboxBLE::_pollRealtime() {
         delay(50);
         resp = _sendCommandDirect(bapi::MET_GET_REALTIME);
     }
-    if (!resp.isEmpty()) _storeCache(_cachedRealtimeJson, _seqRealtime, resp);
+    if (!resp.isEmpty()) {
+        _storeCache(_cachedRealtimeJson, _seqRealtime, resp);
+        // Keep the discrete lock state fresh. r_lck is only read once (in
+        // _connect), so the HA "Lock state" entity would freeze at its
+        // connect-time value if the user locks/unlocks later — it read 0 at
+        // connect and never moved (forum: Kenneth, lock_status stuck at 0
+        // after locking). r_sta.lock_status carries the same 0=unlocked /
+        // 1=locked fact and updates every poll, so mirror it here.
+        JsonDocument d;
+        if (deserializeJson(d, resp) == DeserializationError::Ok &&
+            d["r"]["lock_status"].is<int>()) {
+            _chgLockState = d["r"]["lock_status"].as<int32_t>();
+        }
+    }
 }
 
 void WallboxBLE::_pollSettings() {

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1896,17 +1896,6 @@ bool WallboxBLE::isCharging() {
     return false;
 }
 
-bool WallboxBLE::isPlusCommandFamily() const {
-    // Prefer the charger's own project self-report over the (possibly
-    // transport-clobbered) configured model. A Pulsar Plus on the MAX
-    // single-char BLE transport auto-switches cfg.chargerModel to "max", but
-    // its w_cha stop still needs the Plus parameter (par=0). See wb_web stop.
-    const String m = inferredModel();   // from _chgProject (fw_v_.p), "" if unknown
-    if (m.length())
-        return m == "plus" || m == "copper" || m == "quasar" || m == "quasar2";
-    return configMgr.isPlusFamily();    // project not read yet → configured model
-}
-
 bool WallboxBLE::startStopRedundant(bool wantStart) {
     // A "start" while already charging, or a "stop" while already stopped, is a
     // redundant w_cha write. Harmless on most chargers, but some (e.g. Pulsar

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1585,7 +1585,7 @@ void WallboxBLE::_pollRealtime() {
         // Keep the discrete lock state fresh. r_lck is only read once (in
         // _connect), so the HA "Lock state" entity would freeze at its
         // connect-time value if the user locks/unlocks later — it read 0 at
-        // connect and never moved (forum: Kenneth, lock_status stuck at 0
+        // connect and never moved (forum report: lock_status stuck at 0
         // after locking). r_sta.lock_status carries the same 0=unlocked /
         // 1=locked fact and updates every poll, so mirror it here.
         JsonDocument d;

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -209,7 +209,7 @@ static void populateDeviceBlock(JsonObject dev) {
     // chg_project self-report), not the BLE transport family the auto-switch
     // adopted — a Pulsar Plus on the Max single-char stack is a Plus, even
     // though its transport (and stop parameter) are handled as "max". Falls back
-    // to the configured transport model until fw_v_ is read. (forum: Kenneth)
+    // to the configured transport model until fw_v_ is read. (forum report)
     String prodModel = wallboxBLE.inferredModel();
     if (prodModel.isEmpty()) prodModel = cfg.chargerModel;
     configMgr.productNameFor(prodModel, _fullName, _shortName);

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -205,7 +205,14 @@ static void populateDeviceBlock(JsonObject dev) {
     const WBConfig& cfg = configMgr.get();
     dev["identifiers"][0] = cfg.haDeviceId;
     const char* _fullName = nullptr; const char* _shortName = nullptr;
-    configMgr.productName(_fullName, _shortName);
+    // The HA device card shows the true PRODUCT (from the charger's own
+    // chg_project self-report), not the BLE transport family the auto-switch
+    // adopted — a Pulsar Plus on the Max single-char stack is a Plus, even
+    // though its transport (and stop parameter) are handled as "max". Falls back
+    // to the configured transport model until fw_v_ is read. (forum: Kenneth)
+    String prodModel = wallboxBLE.inferredModel();
+    if (prodModel.isEmpty()) prodModel = cfg.chargerModel;
+    configMgr.productNameFor(prodModel, _fullName, _shortName);
     dev["name"]         = _fullName;
     dev["manufacturer"] = "Wallbox";
     dev["model"]        = _shortName;

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1120,13 +1120,16 @@ static void handleApiCommand() {
     const char* met = nullptr;
     String par;
     if      (action == "start")   { met = bapi::MET_START_STOP;  par = "1"; }
-    // w_cha stop par: 2 for Pulsar MAX (hard stop), 0 for Pulsar Plus
-    // family (pause semantics — Plus ACKs par=2 but ignores it).
-    // Mirrors jagheterfredrik/wallbox-ble's Plus convention. See #4.
-    // Keys on the charger's OWN model (chg_project), not the BLE transport the
-    // auto-switch adopted — a Plus on the MAX single-char transport is labelled
-    // "max" in config but still needs par=0 (forum: Kenneth's Pulsar Plus).
-    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = wallboxBLE.isPlusCommandFamily() ? "0" : "2"; }
+    // w_cha stop par tracks the BLE STACK (transport), NOT the marketing model:
+    //   - dual-char stack (BGX Pulsar Plus / Copper / Quasar) honour par=0 and
+    //     only ACK-then-ignore par=2 (see #99);
+    //   - single-char stack (Pulsar MAX, AND Pulsar Plus units on the NINA-B22
+    //     single-char stack) need par=2.
+    // isPlusFamily() reflects the transport family the auto-switch adopts, so
+    // it's the correct signal. NB a "Pulsar Plus" is NOT always par=0 —
+    // Kenneth's prj08-pulsar-plus-pm3 (NINA-B22, single-char) confirmed par=2
+    // stops it and par=0 does nothing. See #4 / forum.
+    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = configMgr.isPlusFamily() ? "0" : "2"; }
     // Resume — clears schedule/eco override flag (r_dat.gen -> 0).
     // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging,
     // so we queue a defensive Stop first in that case alone. Sending the
@@ -1134,7 +1137,7 @@ static void handleApiCommand() {
     // harmless no-op — it can fault the charger (error 114), so we skip it.
     else if (action == "resume")  {
         if (wallboxBLE.isCharging()) {
-            const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
+            const char* stopPar = configMgr.isPlusFamily() ? "0" : "2";
             wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
         }
         met = "s_cmode";             par = "{\"mode\":0}";

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1108,6 +1108,8 @@ static void handleApiCommand() {
     // TOGGLE and flip the wrong way. Report success (already in target state).
     if ((action == "start" || action == "stop") &&
         wallboxBLE.startStopRedundant(action == "start")) {
+        Log.printf("[CMD] %s SKIPPED as redundant (isCharging=%d)\n",
+                   action.c_str(), (int)wallboxBLE.isCharging());
         http.send(200, "application/json",
             "{\"status\":\"ok\",\"skipped\":\"already-in-target-state\"}");
         return;
@@ -1126,7 +1128,13 @@ static void handleApiCommand() {
     // single-char stack is still a Plus (par=0) — confirmed on Kenneth's
     // prj08-pulsar-plus-pm3. isPlusCommandFamily() reads chg_project, falling
     // back to the configured model until fw_v_ is read.
-    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = wallboxBLE.isPlusCommandFamily() ? "0" : "2"; }
+    else if (action == "stop")    {
+        met = bapi::MET_START_STOP;
+        par = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
+        Log.printf("[CMD] stop: chg_project='%s' inferred='%s' isPlusCmd=%d -> w_cha par=%s\n",
+                   wallboxBLE.chargerProject().c_str(), wallboxBLE.inferredModel().c_str(),
+                   (int)wallboxBLE.isPlusCommandFamily(), par.c_str());
+    }
     // Resume — clears schedule/eco override flag (r_dat.gen -> 0).
     // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging,
     // so we queue a defensive Stop first in that case alone. Sending the

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1123,7 +1123,10 @@ static void handleApiCommand() {
     // w_cha stop par: 2 for Pulsar MAX (hard stop), 0 for Pulsar Plus
     // family (pause semantics — Plus ACKs par=2 but ignores it).
     // Mirrors jagheterfredrik/wallbox-ble's Plus convention. See #4.
-    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = configMgr.isPlusFamily() ? "0" : "2"; }
+    // Keys on the charger's OWN model (chg_project), not the BLE transport the
+    // auto-switch adopted — a Plus on the MAX single-char transport is labelled
+    // "max" in config but still needs par=0 (forum: Kenneth's Pulsar Plus).
+    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = wallboxBLE.isPlusCommandFamily() ? "0" : "2"; }
     // Resume — clears schedule/eco override flag (r_dat.gen -> 0).
     // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging,
     // so we queue a defensive Stop first in that case alone. Sending the
@@ -1131,7 +1134,7 @@ static void handleApiCommand() {
     // harmless no-op — it can fault the charger (error 114), so we skip it.
     else if (action == "resume")  {
         if (wallboxBLE.isCharging()) {
-            const char* stopPar = configMgr.isPlusFamily() ? "0" : "2";
+            const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
             wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
         }
         met = "s_cmode";             par = "{\"mode\":0}";

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1120,16 +1120,13 @@ static void handleApiCommand() {
     const char* met = nullptr;
     String par;
     if      (action == "start")   { met = bapi::MET_START_STOP;  par = "1"; }
-    // w_cha stop par tracks the BLE STACK (transport), NOT the marketing model:
-    //   - dual-char stack (BGX Pulsar Plus / Copper / Quasar) honour par=0 and
-    //     only ACK-then-ignore par=2 (see #99);
-    //   - single-char stack (Pulsar MAX, AND Pulsar Plus units on the NINA-B22
-    //     single-char stack) need par=2.
-    // isPlusFamily() reflects the transport family the auto-switch adopts, so
-    // it's the correct signal. NB a "Pulsar Plus" is NOT always par=0 —
-    // Kenneth's prj08-pulsar-plus-pm3 (NINA-B22, single-char) confirmed par=2
-    // stops it and par=0 does nothing. See #4 / forum.
-    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = configMgr.isPlusFamily() ? "0" : "2"; }
+    // w_cha stop par follows the charger's PRODUCT (chg_project), not the BLE
+    // transport: Pulsar Plus family -> par=0 (pause; a Plus ACKs par=2 but
+    // ignores it, see #99), Pulsar MAX -> par=2 (hard stop). A Plus on the Max
+    // single-char stack is still a Plus (par=0) — confirmed on Kenneth's
+    // prj08-pulsar-plus-pm3. isPlusCommandFamily() reads chg_project, falling
+    // back to the configured model until fw_v_ is read.
+    else if (action == "stop")    { met = bapi::MET_START_STOP;  par = wallboxBLE.isPlusCommandFamily() ? "0" : "2"; }
     // Resume — clears schedule/eco override flag (r_dat.gen -> 0).
     // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging,
     // so we queue a defensive Stop first in that case alone. Sending the
@@ -1137,7 +1134,7 @@ static void handleApiCommand() {
     // harmless no-op — it can fault the charger (error 114), so we skip it.
     else if (action == "resume")  {
         if (wallboxBLE.isCharging()) {
-            const char* stopPar = configMgr.isPlusFamily() ? "0" : "2";
+            const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
             wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
         }
         met = "s_cmode";             par = "{\"mode\":0}";
@@ -1463,11 +1460,14 @@ function _clearLive(){
   var cr=document.getElementById('charge-reminder');if(cr)cr.style.display='none';
   try{localStorage.removeItem('wb-last-status');localStorage.removeItem('wb-last-meter')}catch(e){}
 }
-function applyStatusData(s,rt){if(!s||typeof s!=='object')return;if(typeof s.st==='number'){var n=(window._zentri&&ZN[s.st]!==undefined)?ZN[s.st]:SN[s.st];if(s.st===4&&!window._zentri&&!(typeof s.gen==='number'&&s.gen!==0))n='Connected — not charging';_setText('v-st',n||'Code '+s.st)}var pb=document.getElementById('paused-banner');if(pb)pb.style.display=(typeof s.gen==='number'&&s.gen!==0)?'flex':'none';_setNum('v-pw',s.cp,' kW',function(v){return v.toFixed(2)});if(typeof s.cp==='number')_pfState.cp=s.cp;if(typeof s.en==='number')_pfState.en=s.en;if(typeof s.st==='number')_pfState.conn=_carConn(s.st);_pfRender();var threePhase=(s.L2>0||s.L3>0||(rt&&rt.phases_connection>=2));if(typeof s.L1==='number'){var l1=(s.L1/10).toFixed(1);if(threePhase&&typeof s.L2==='number'&&typeof s.L3==='number'){_setText('l-cr','L1 / L2 / L3');_setText('v-cr',l1+' / '+(s.L2/10).toFixed(1)+' / '+(s.L3/10).toFixed(1)+' A')}else{_setText('l-cr','Charging Current');_setText('v-cr',l1+' A')}}_setNum('v-en',s.en,' kWh',function(v){return (v/100).toFixed(2)});if(typeof s.cur==='number'){_setText('v-mc',s.cur+' A');var sl=document.getElementById('sl');if(sl)sl.value=s.cur;_setText('sv',s.cur+'A')}try{localStorage.setItem('wb-last-status',JSON.stringify({s:s,rt:rt,t:Date.now()}))}catch(e){}if(rt&&typeof rt==='object'){if(typeof rt.lock_status==='number')_setText('v-lk',rt.lock_status==0?'Unlocked':'Locked');if(typeof rt.ocpp_status==='number'){var os={0:'Not Available',1:'Not Configured',2:'Connected',3:'Charging'};_setText('v-oc',os[rt.ocpp_status]||'Code '+rt.ocpp_status)}}window._lastUpdate=Date.now()}
+function applyStatusData(s,rt){if(!s||typeof s!=='object')return;if(typeof s.st==='number'){var n=(window._zentri&&ZN[s.st]!==undefined)?ZN[s.st]:SN[s.st];if(s.st===4&&!window._zentri&&!(typeof s.gen==='number'&&s.gen!==0))n='Connected — not charging';_setText('v-st',n||'Code '+s.st)}var pb=document.getElementById('paused-banner');if(pb)pb.style.display=(typeof s.gen==='number'&&s.gen!==0)?'flex':'none';_setNum('v-pw',s.cp,' kW',function(v){return v.toFixed(2)});if(typeof s.cp==='number')_pfState.cp=s.cp;if(typeof s.en==='number')_pfState.en=s.en;if(typeof s.st==='number')_pfState.conn=_carConn(s.st);_pfRender();var threePhase=(s.L2>0||s.L3>0||(rt&&rt.phases_connection>=2));if(typeof s.L1==='number'){var l1=(s.L1/10).toFixed(1);if(threePhase&&typeof s.L2==='number'&&typeof s.L3==='number'){_setText('l-cr','L1 / L2 / L3');_setText('v-cr',l1+' / '+(s.L2/10).toFixed(1)+' / '+(s.L3/10).toFixed(1)+' A')}else{_setText('l-cr','Charging Current');_setText('v-cr',l1+' A')}}_setNum('v-en',s.en,' kWh',function(v){return (v/100).toFixed(2)});if(typeof s.cur==='number'){_setText('v-mc',s.cur+' A');var sl=document.getElementById('sl');if(sl)sl.value=s.cur;_setText('sv',s.cur+'A')}try{localStorage.setItem('wb-last-status',JSON.stringify({s:s,rt:rt,t:Date.now()}))}catch(e){}if(rt&&typeof rt==='object')applyRT(rt);window._lastUpdate=Date.now()}
+// Realtime (r_sta) fields — lock + OCPP. Shared by the polled path (rt arg) and
+// the 'realtime' WS push, so lock state updates live even when WS-driven.
+function applyRT(rt){if(!rt||typeof rt!=='object')return;if(typeof rt.lock_status==='number')_setText('v-lk',rt.lock_status==0?'Unlocked':'Locked');if(typeof rt.ocpp_status==='number'){var os={0:'Not Available',1:'Not Configured',2:'Connected',3:'Charging'};_setText('v-oc',os[rt.ocpp_status]||'Code '+rt.ocpp_status)}}
 function applyMeterData(d){if(!d||typeof d!=='object')return;if(typeof d.v1==='number'){var vt=document.getElementById('v-vt');if(vt)vt.textContent=d.v1+' V'}if(typeof d.p1==='number'){var gp=document.getElementById('v-gp');if(gp)gp.textContent=d.p1+' W'}var house=(d.p1||0)+(d.p2||0)+(d.p3||0);_pfState.house=house;_pfRender();try{localStorage.setItem('wb-last-meter',JSON.stringify({d:d,t:Date.now()}))}catch(e){}}
 function P(){if(window.wbws&&window.wbws.isOpen())return;fetch('/api/charger').then(function(r){return r.json()}).then(function(d){if(!d.status||d.status==='null'){/* BLE not delivering charger status — reset power flow + session cache so the animation can't outlive a BLE drop on stale localStorage values */_pfState.cp=null;_pfState.en=null;_pfRender();return}var s=d.status?d.status.r:null,rt=d.realtime?d.realtime.r:null;applyStatusData(s,rt)}).catch(function(){});fetch('/api/command?action=bapi&met=r_dca&par=null').then(function(r){return r.json()}).then(function(d){if(!d||!d.r){_pfState.house=null;_pfRender();return}applyMeterData(d.r)}).catch(function(){_pfState.house=null;_pfRender()})}
 // Hook WS push handlers
-if(window.wbws){window.wbws.subscribe('status',function(d){var s=d&&d.r?d.r:d;applyStatusData(s,null);if(window.wbCheckStatus)window.wbCheckStatus(s)});window.wbws.subscribe('meter',function(d){applyMeterData(d&&d.r?d.r:d)});window.wbws.subscribe('ble',function(d){if(d&&d.state&&d.state!=='connected')_clearLive()});}
+if(window.wbws){window.wbws.subscribe('status',function(d){var s=d&&d.r?d.r:d;applyStatusData(s,null);if(window.wbCheckStatus)window.wbCheckStatus(s)});window.wbws.subscribe('meter',function(d){applyMeterData(d&&d.r?d.r:d)});window.wbws.subscribe('realtime',function(d){applyRT(d&&d.r?d.r:d)});window.wbws.subscribe('ble',function(d){if(d&&d.state&&d.state!=='connected')_clearLive()});}
 // Render cached values immediately (no spinners)
 try{var c=JSON.parse(localStorage.getItem('wb-last-status')||'null');if(c)applyStatusData(c.s,c.rt)}catch(e){}
 try{var cm=JSON.parse(localStorage.getItem('wb-last-meter')||'null');if(cm)applyMeterData(cm.d)}catch(e){}

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1125,7 +1125,7 @@ static void handleApiCommand() {
     // w_cha stop par follows the charger's PRODUCT (chg_project), not the BLE
     // transport: Pulsar Plus family -> par=0 (pause; a Plus ACKs par=2 but
     // ignores it, see #99), Pulsar MAX -> par=2 (hard stop). A Plus on the Max
-    // single-char stack is still a Plus (par=0) — confirmed on Kenneth's
+    // single-char stack is still a Plus (par=0) — confirmed on a forum report's
     // prj08-pulsar-plus-pm3. isPlusCommandFamily() reads chg_project, falling
     // back to the configured model until fw_v_ is read.
     else if (action == "stop")    {

--- a/src/wb_web_async.cpp
+++ b/src/wb_web_async.cpp
@@ -1011,11 +1011,19 @@ static void _registerBleRoutes() {
         const char* met = nullptr;
         String par;
         if      (action == "start")   { met = bapi::MET_START_STOP;  par = "1"; }
-        // w_cha stop par: 2 for Pulsar MAX, 0 for Pulsar Plus family.
-        // Plus ACKs par=2 but ignores it (charger keeps charging);
-        // par=0 is the pause/stop value per jagheterfredrik/wallbox-ble.
-        // Reported by peter-mcc on issue #4.
-        else if (action == "stop")    { met = bapi::MET_START_STOP;  par = configMgr.isPlusFamily() ? "0" : "2"; }
+        // w_cha stop par follows the charger's PRODUCT (chg_project), not the
+        // BLE transport the auto-switch adopts: Pulsar Plus family -> par=0
+        // (a Plus ACKs par=2 but ignores it, #4/#99), Pulsar MAX -> par=2. A
+        // Plus on the Max single-char stack is still a Plus (par=0) — confirmed
+        // on Kenneth's prj08-pulsar-plus-pm3. isPlusCommandFamily() reads
+        // chg_project, falling back to the configured model until fw_v_ is read.
+        else if (action == "stop")    {
+            met = bapi::MET_START_STOP;
+            par = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
+            Log.printf("[CMD] stop: chg_project='%s' inferred='%s' isPlusCmd=%d -> w_cha par=%s\n",
+                       wallboxBLE.chargerProject().c_str(), wallboxBLE.inferredModel().c_str(),
+                       (int)wallboxBLE.isPlusCommandFamily(), par.c_str());
+        }
         // Resume clears the schedule/eco manual-override flag
         // (r_dat.gen != 0 -> 0). The charger rejects s_cmode mode=0
         // (subcode 6) ONLY when actively charging (st=1), so we queue a
@@ -1026,7 +1034,7 @@ static void _registerBleRoutes() {
         // s_cmode mode=0 alone lands gen=0 from the paused/idle state.
         else if (action == "resume")  {
             if (wallboxBLE.isCharging()) {
-                const char* stopPar = configMgr.isPlusFamily() ? "0" : "2";
+                const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
                 wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
             }
             met = "s_cmode";             par = "{\"mode\":0}";

--- a/src/wb_web_async.cpp
+++ b/src/wb_web_async.cpp
@@ -1015,7 +1015,7 @@ static void _registerBleRoutes() {
         // BLE transport the auto-switch adopts: Pulsar Plus family -> par=0
         // (a Plus ACKs par=2 but ignores it, #4/#99), Pulsar MAX -> par=2. A
         // Plus on the Max single-char stack is still a Plus (par=0) — confirmed
-        // on Kenneth's prj08-pulsar-plus-pm3. isPlusCommandFamily() reads
+        // on a prj08-pulsar-plus-pm3. isPlusCommandFamily() reads
         // chg_project, falling back to the configured model until fw_v_ is read.
         else if (action == "stop")    {
             met = bapi::MET_START_STOP;


### PR DESCRIPTION
Stable v3.2.4. All fixes confirmed on a Pulsar Plus that rides the Max single-char BLE stack (u-blox NINA-B22, prj08-pulsar-plus-pm3), reported on the HA forum.

## Fixed
- **Stop works** on a Pulsar Plus with the Max BLE stack — `w_cha` stop param follows the charger's product (`chg_project` → Plus `par=0`), not the BLE transport. Applied to **both** command handlers (the live async one had been missed across the betas).
- **Lock state tracks live** — refreshed from the periodic `r_sta` poll, not once at connect; broadcast over a new `realtime` WS channel so the web dashboard updates too.
- **HA device card shows the true product** ("Pulsar Plus") from `chg_project`.

Beta soak: beta.1–5; confirmed working end-to-end (Stop `par=0` + lock live) on the reporter's hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)