### PR TITLE
fix(mqtt): send complete s_ecos so the Eco-Smart solar target can be set from HA

### DIFF
--- a/include/wb_ble.h
+++ b/include/wb_ble.h
@@ -607,6 +607,20 @@ public:
     int     lastHaloMode()  const { return _lastHaloMode; }
     int     lastHaloTimeS() const { return _lastHaloTimeS; }
 
+    // Last observed Eco-Smart mode/percentage (g_ecos). s_ecos is rejected in
+    // silence on charger fw 6.11.x unless all three fields (ese/esm/esp) are
+    // present — the web UI already learned this the hard way (saveEco() in
+    // wb_web.cpp). The MQTT handlers only carry one field each (the select
+    // sends the mode, the number sends the percentage), so we stash the other
+    // one from each settings poll and replay it, exactly like halo/autolock.
+    // Defaults match the charger's own (Eco-Smart off, 100 % solar target).
+    int     _lastEcoMode    = 0;
+    int     _lastEcoPct     = 100;
+    int     _lastEcoEnabled = 0;
+    int     lastEcoMode()    const { return _lastEcoMode; }
+    int     lastEcoPct()     const { return _lastEcoPct; }
+    int     lastEcoEnabled() const { return _lastEcoEnabled; }
+
 private:
     String _chargerModel = "max";
     uint32_t _mainsVoltage = 230;   // phase-current power derivation fallback (#12)

--- a/src/wb_ble.cpp
+++ b/src/wb_ble.cpp
@@ -1654,6 +1654,13 @@ void WallboxBLE::_pollSettings() {
                 // back on every attempt to select Off. Gate on `ese` (#29).
                 merged["eco_mode"] = (d["r"]["ese"] | 0) ? (d["r"]["esm"] | 0) : 0;
                 merged["eco_power"] = d["r"]["esp"] | 100;
+                // Stash the raw pair so an MQTT write can rebuild the whole
+                // s_ecos object (see lastEcoMode/lastEcoPct in wb_ble.h). Note
+                // `esm` is kept raw here, ungated by `ese`: it is the mode to
+                // restore when the percentage changes while Eco-Smart is on.
+                _lastEcoMode    = d["r"]["esm"] | 0;
+                _lastEcoPct     = d["r"]["esp"] | 100;
+                _lastEcoEnabled = d["r"]["ese"] | 0;
             } else if (d["error"].is<JsonObject>()) {
                 _ecoSmartPresent = false;
             }

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -731,6 +731,12 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
         int mode = 0;
         if (s.startsWith("Full Green")) mode = 1;
         else if (s == "Solar + Grid") mode = 2;
+        // Preserve the user's solar target instead of forcing it to 100 %:
+        // hard-coding `esp` here silently wiped whatever percentage the user
+        // had configured (and, with the eco_power write broken below, left no
+        // way to set it back from HA). The web UI already replays the current
+        // value in saveEco(); do the same from the last settings poll.
+        String esp = String(wallboxBLE.lastEcoPct());
         if (mode == 0) {
             // Disabling: the charger ignores an `esm` change that arrives
             // together with ese=0, leaving `esm` stuck at its previous value
@@ -738,17 +744,26 @@ void WallboxMQTT::_handleCommand(const char* subtopic, const char* payload) {
             // first with the master flag still ON so it is accepted, then drop
             // the flag — this clears `esm` and leaves the charger at
             // {ese:0, esm:0}.
-            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, "{\"esm\":0,\"ese\":1,\"esp\":100}");
-            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, "{\"esm\":0,\"ese\":0,\"esp\":100}");
+            String on  = "{\"esm\":0,\"ese\":1,\"esp\":" + esp + "}";
+            String off = "{\"esm\":0,\"ese\":0,\"esp\":" + esp + "}";
+            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, on.c_str());
+            wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, off.c_str());
         } else {
-            String p = "{\"esm\":" + String(mode) + ",\"ese\":1,\"esp\":100}";
+            String p = "{\"esm\":" + String(mode) + ",\"ese\":1,\"esp\":" + esp + "}";
             wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, p.c_str());
         }
 
     } else if (sub == "eco_power") {
         int pct = atoi(payload);
         if (pct < 0) pct = 0; if (pct > 100) pct = 100;
-        String p = "{\"esp\":" + String(pct) + "}";
+        // s_ecos needs all three fields — a lone {"esp":N} is silently
+        // rejected on charger fw 6.11.x, exactly like the {mode,esp} payload
+        // the web UI used to send (see the comment in saveEco(), wb_web.cpp).
+        // Replay the last polled mode *and* master flag: writing the solar
+        // target must not switch Eco-Smart on behind the user's back.
+        String p = "{\"esm\":" + String(wallboxBLE.lastEcoMode()) +
+                   ",\"ese\":" + String(wallboxBLE.lastEcoEnabled()) +
+                   ",\"esp\":" + String(pct) + "}";
         wallboxBLE.enqueueRequest(bapi::MET_SET_ECO_SMART, p.c_str());
 
     } else if (sub == "power_sharing") {


### PR DESCRIPTION
Fixes #36.

## Problem

`esp` (Eco-Smart solar target) is unreachable from Home Assistant:

- `eco_power` publishes `s_ecos` with a lone `{"esp":N}` — silently dropped by the charger on fw 6.11.x. Measured on a Pulsar MAX: the HA number entity failed to move `esp` in 5.5 min (~11 settings polls); the same value sent as a full object to `cmd/eco_smart` took effect within a second.
- `eco_mode` hard-codes `esp:100`, so selecting a mode wipes the user's percentage. With the write above broken, it cannot be restored from HA — the user stays pinned at 100 % solar and *Solar + Grid* never mixes grid power.

This is the same class of bug as #29, and the web UI already fixed it on its side: see the comment in `saveEco()` (`src/wb_web.cpp`), which states that `s_ecos` needs all three fields and that `{mode, esp}` was *"silently rejected on fw 6.11.x"*. `saveEco()` also replays the current percentage when changing mode; the MQTT path did not.

## Change

- `include/wb_ble.h`: cache `_lastEcoMode` / `_lastEcoPct` / `_lastEcoEnabled` with getters, next to the existing halo and auto-lock caches, following the same rationale and comment style.
- `src/wb_ble.cpp`: populate them in `_pollSettings()`, where `esm`/`esp`/`ese` are already parsed. `esm` is stored raw (ungated by `ese`) because it is the mode to restore later; the published `eco_mode` keeps its `ese` gate from #29 untouched.
- `src/wb_mqtt.cpp`: both handlers now send the complete object. `eco_mode` replays the polled percentage instead of forcing 100; `eco_power` replays the polled mode **and** master flag, so writing the target cannot switch Eco-Smart on behind the user's back.

No new entities, no config changes, no behaviour change for users who leave the target at 100 %.

## Testing

Behaviour verified in production against a Pulsar MAX (fw 6.11.25) by publishing the equivalent full object to `wallbox/<id>/cmd/eco_smart`: `esp` went 100 → 50 immediately, and after restarting the charge session the charger blended grid power as expected (7.7 A / 1.82 kW fully solar → 15.4 A / 3.62 kW with 1508 W imported).

Note: the charger applies a new solar target **when the session starts**, not mid-session — worth a docs line, happy to add it if you want.

I could not build the firmware locally (no ESP32 toolchain on this machine), so please give the compile a look — the change is small and mirrors existing code, but I would not want a typo to reach a release.

## Possibly related, unverified

`power_sharing` sends `{"dyps":N}` while `g_psh` returns `{dyps, mcpp, minI, nchg}`. If `s_psh` behaves like `s_ecos`, it would be dropped the same way. Not tested — it needs the car unplugged.
