### PR TITLE
v3.2.7 — command-handler dedup (#179), WROOM target + 8MB table + charge-log→nvs2 (#154), MQTT log-noise (#31)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,14 @@ on:
       - 'include/**'
       - 'platformio.ini'
       - 'partitions_ota.csv'
+      - 'partitions_8mb.csv'
   pull_request:
     paths:
       - 'src/**'
       - 'include/**'
       - 'platformio.ini'
       - 'partitions_ota.csv'
+      - 'partitions_8mb.csv'
   release:
     types: [created]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Build ESP32-S3 firmware
         run: pio run -e esp32s3
 
+      # Classic ESP32-WROOM (esp32dev, #154). Built on every push/PR/release so
+      # the second target can't silently regress. NOT attached to releases yet —
+      # it compiles + fits 4 MB, but is pending on-hardware validation, so it's
+      # only offered as a CI artifact for testers (below), not as a release asset.
+      - name: Build ESP32-WROOM (esp32dev) firmware
+        run: pio run -e esp32dev
+
+      - name: Upload ESP32-WROOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-esp32dev
+          path: |
+            .pio/build/esp32dev/firmware.bin
+            .pio/build/esp32dev/firmware.elf
+            .pio/build/esp32dev/bootloader.bin
+            .pio/build/esp32dev/partitions.bin
+
       - name: Compute SHA256
         run: |
           cd .pio/build/esp32s3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Classic ESP32-WROOM build target (`esp32dev`, #154).** The gateway now
+  builds for the common/cheaper classic ESP32-WROOM-32 module, not just the
+  ESP32-S3. `platformio.ini` is refactored to a shared `[common]` base with
+  per-board envs (`esp32s3` keeps the USB-CDC-on-boot flag; `esp32dev` omits it
+  — classic ESP32 serial is UART0). The 4 MB flash fits `partitions_ota.csv`
+  exactly (~20% app headroom); `chip_temp` has no usable die sensor on classic
+  ESP32 and was already gated off, so the Gateway Temperature entity just reads
+  unavailable there. Build with `pio run -e esp32dev`.
+
 ## [3.2.6] - 2026-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   exactly (~20% app headroom); `chip_temp` has no usable die sensor on classic
   ESP32 and was already gated off, so the Gateway Temperature entity just reads
   unavailable there. Build with `pio run -e esp32dev`.
+- **Bigger OTA app slots on the ESP32-S3 (8 MB partition table).** The S3 (8 MB
+  flash) now uses `partitions_8mb.csv` with **3 MB** OTA app slots (was 1.875 MB
+  — the app went from 74% → 46% of its slot) plus a 256 KB coredump, so there's
+  room for the app to grow. The WROOM keeps the tight 4 MB table. A partition-
+  table change can't be applied over OTA, so existing S3 installs keep the old
+  slots until a USB re-flash; only new USB installs get the bigger ones.
+- **Longer on-board charge history on the S3** (`MAX_INTERVALS` 24 → 96), so the
+  month cost/savings sensors (#151) don't undercount a busy month by dropping
+  older charge bursts from the ring. The WROOM keeps 24 to conserve RAM.
+
+### Changed
+- **Charge-log moved to its own `nvs2` partition.** It previously shared the
+  20 KB default `nvs` with settings, and a growing ring could crowd that
+  partition until writes silently failed and the ring stranded at its last-
+  fitting size (the #166 symptom). `nvs2` (64 KB, allocated but until now
+  unused) is formatted on first boot and the existing history is migrated into
+  it once — so settings and the charge-log no longer compete for space.
 
 ## [3.2.6] - 2026-08-16
 

--- a/include/wb_charge_log.h
+++ b/include/wb_charge_log.h
@@ -32,8 +32,17 @@
 
 namespace wb_charge_log {
 
-// Ring size. Each interval is small; ~24 covers a few days of typical use.
+// Ring size. Each interval is a small (~60 B) JSON record, persisted in the
+// dedicated nvs2 partition (64 KB) so it no longer crowds settings in the 20 KB
+// default nvs (see the migration in .cpp — that crowding was the #166 silent-
+// fail). The classic ESP32-WROOM keeps a shorter ring to conserve RAM; the S3
+// holds a longer history so month cost/savings (#151) doesn't undercount a busy
+// month (a 24-burst ring can drop older bursts within a single month).
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+static const uint8_t MAX_INTERVALS = 96;
+#else
 static const uint8_t MAX_INTERVALS = 24;
+#endif
 
 // Charging is "on" when cp exceeds this (kW) — filters meter noise / standby.
 static constexpr float CP_ON_KW = 0.10f;

--- a/include/wb_cmd.h
+++ b/include/wb_cmd.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <Arduino.h>
+
+// Shared /api/command action resolver (#179). The sync (wb_web.cpp) and async
+// (wb_web_async.cpp) handlers used to carry byte-identical copies of the
+// action -> BAPI met/par mapping, the idempotent start/stop skip, the
+// control-owner tagging, the model-aware stop parameter, the resume defensive-
+// Stop, and the current clamp. They drifted repeatedly (the Pulsar-Plus stop
+// par and the 40 A current ceiling were each fixed in one copy but not the
+// other across several releases). This module holds the ONE copy; each handler
+// only does its own transport-specific param extraction and response sending.
+namespace wb_cmd {
+
+struct Plan {
+    // ENQUEUE -> caller enqueues {met, par} on the BLE queue.
+    // RESPOND -> caller sends `responseJson` with `statusCode` and returns
+    //            (idempotent skip = 200, bad request = 400).
+    enum Outcome { ENQUEUE, RESPOND };
+    Outcome outcome = ENQUEUE;
+    String  met;
+    String  par;
+    String  responseJson;
+    int     statusCode = 200;
+};
+
+// Resolve a command. `value` is used only by action=="current"; `metParam` /
+// `parParam` only by action=="bapi". May perform transport-agnostic side
+// effects on the global charger: wb_control::recordCommand(owner) for
+// charge-affecting actions, and — for "resume" while actively charging — a
+// defensive Stop enqueued ahead of the s_cmode write. enqueueRequest() copies
+// met/par, so the returned Plan only needs to outlive the caller's enqueue call.
+Plan buildCommand(const String& action, const String& value,
+                  const String& owner, const String& metParam,
+                  const String& parParam);
+
+}  // namespace wb_cmd

--- a/partitions_8mb.csv
+++ b/partitions_8mb.csv
@@ -1,0 +1,20 @@
+# Wallbox BLE Gateway - 8 MB partition table (ESP32-S3).
+#
+# The classic ESP32-WROOM (esp32dev) keeps the tight 4 MB partitions_ota.csv;
+# the S3 has 8 MB, so it gets 3 MB OTA app slots (vs 1.875 MB) for app-growth
+# headroom, and a bigger 256 KB coredump. nvs2 hosts the charge-log on both
+# tables (Preferences finds it by label regardless of offset). ~1.3 MB is left
+# unallocated for a future data/filesystem partition.
+#
+# NOTE: like any partition-table change this CANNOT be applied over OTA. Existing
+# S3 installs keep the 4 MB table (1.875 MB slots) until a USB re-flash; only new
+# USB installs get the bigger slots. nvs (0x9000) keeps its offset so settings
+# survive. See docs/INSTALL.md.
+#
+# Name,   Type, SubType,  Offset,   Size
+nvs,      data, nvs,      0x9000,   0x5000,
+otadata,  data, ota,      0xe000,   0x2000,
+app0,     app,  ota_0,    0x10000,  0x300000,
+app1,     app,  ota_1,    0x310000, 0x300000,
+coredump, data, coredump, 0x610000, 0x40000,
+nvs2,     data, nvs,      0x650000, 0x10000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,9 +38,12 @@ build_flags =
     -D WB_ASYNC_WEB=1
 
 ; ESP32-S3-DevKitC-1 (the reference/primary board). USB-CDC serial on boot.
+; 8 MB flash -> the larger partition table (3 MB OTA app slots vs the WROOM's
+; 1.875 MB) for app-growth headroom. WROOM stays on the 4 MB partitions_ota.csv.
 [env:esp32s3]
 extends = common
 board = esp32-s3-devkitc-1
+board_build.partitions = partitions_8mb.csv
 build_flags =
     ${common.build_flags}
     -D ARDUINO_USB_CDC_ON_BOOT=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,7 @@
-[env:esp32s3]
+; Shared config for every build target. Board-specific bits (the board id and
+; the S3-only USB-CDC flag) live in the per-env sections below.
+[common]
 platform = espressif32
-board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
@@ -27,7 +28,6 @@ build_flags =
     -D CONFIG_BT_NIMBLE_ROLE_OBSERVER=1
     -D CONFIG_BT_NIMBLE_ROLE_BROADCASTER=0
     -D CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
-    -D ARDUINO_USB_CDC_ON_BOOT=1
     ; 3.0 task #78 — async webserver migration build flag.
     ; Default 1 = production: async on :80 (sync retired in STA per
     ; commit 6bf557b — when WB_ASYNC_WEB=0, STA mode has NO HTTP
@@ -36,6 +36,23 @@ build_flags =
     ; longer binds a listener. Set to 0 only for sync-only legacy
     ; testing builds. Both paths build clean.
     -D WB_ASYNC_WEB=1
+
+; ESP32-S3-DevKitC-1 (the reference/primary board). USB-CDC serial on boot.
+[env:esp32s3]
+extends = common
+board = esp32-s3-devkitc-1
+build_flags =
+    ${common.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+
+; Classic ESP32-WROOM-32 (esp32dev) — the common/cheaper module (#154). 4 MB
+; flash fits partitions_ota.csv exactly. No USB-CDC (serial is UART0), so the
+; ARDUINO_USB_CDC_ON_BOOT flag is omitted. chip_temp has no usable die sensor
+; on classic ESP32 and is already gated off (wb_web.h) — the Gateway
+; Temperature entity just reads unavailable.
+[env:esp32dev]
+extends = common
+board = esp32dev
 
 ; For OTA: pio run -e ota -t upload --upload-port <IP> [--upload-flags="--auth=<password>"]
 ; The OTA password is shown in the serial log on boot.

--- a/src/wb_charge_log.cpp
+++ b/src/wb_charge_log.cpp
@@ -2,12 +2,18 @@
 #include "wb_log.h"
 #include <Preferences.h>
 #include <ArduinoJson.h>
+#include <nvs_flash.h>
 #include <time.h>
 
 namespace wb_charge_log {
 
-static const char* NVS_NS  = "wbcharge";
-static const char* NVS_KEY = "ivals";
+static const char* NVS_NS   = "wbcharge";
+static const char* NVS_KEY  = "ivals";
+// The charge-log lives in its OWN nvs partition (nvs2, 64 KB) so a growing ring
+// can't crowd settings in the 20 KB default nvs — that crowding stranded the
+// ring at its last-fitting size (#166). nvs2 was allocated in the partition
+// table but previously unused; _initNvs2() formats it on first use.
+static const char* NVS_PART = "nvs2";
 
 // SNTP-synced guard: before this the clock is the 1970 boot default, so any
 // timestamp would be garbage. Matches the wb_ble / wb_health convention.
@@ -45,7 +51,7 @@ static volatile uint32_t _lastBurstWh = 0;
 
 static void load(JsonDocument& doc) {
     Preferences p;
-    if (!p.begin(NVS_NS, true)) { doc.to<JsonArray>(); return; }
+    if (!p.begin(NVS_NS, true, NVS_PART)) { doc.to<JsonArray>(); return; }
     String s = p.getString(NVS_KEY, "[]");
     p.end();
     if (deserializeJson(doc, s) != DeserializationError::Ok || !doc.is<JsonArray>()) {
@@ -56,7 +62,7 @@ static void load(JsonDocument& doc) {
 
 static void store(const JsonDocument& doc) {
     Preferences p;
-    if (!p.begin(NVS_NS, false)) {
+    if (!p.begin(NVS_NS, false, NVS_PART)) {
         Log.println("[chargelog] NVS begin(rw) failed — interval NOT persisted");
         return;
     }
@@ -104,7 +110,7 @@ static uint32_t _burstGreenWh(uint32_t wh) {
 
 static void saveOpenState() {
     Preferences p;
-    if (!p.begin(NVS_NS, false)) return;
+    if (!p.begin(NVS_NS, false, NVS_PART)) return;
     if (_open) {
         uint32_t wh = _burstWh();
         JsonDocument d;
@@ -138,9 +144,61 @@ static void appendInterval(uint32_t usid, uint32_t start, uint32_t stop,
     _count = (uint8_t)arr.size();
 }
 
+// Format/open the dedicated nvs2 partition on first use. It was allocated in
+// the partition table but never initialised, so a fresh one has no NVS pages —
+// erase + re-init once, the standard custom-partition pattern.
+static void _initNvs2() {
+    esp_err_t e = nvs_flash_init_partition(NVS_PART);
+    if (e == ESP_ERR_NVS_NO_FREE_PAGES || e == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        nvs_flash_erase_partition(NVS_PART);
+        e = nvs_flash_init_partition(NVS_PART);
+    }
+    if (e != ESP_OK)
+        Log.printf("[chargelog] nvs2 init failed (%d) — charge-log won't persist\n", (int)e);
+}
+
+// One-time move of the charge-log from the crowded 20 KB default nvs into the
+// dedicated nvs2 partition. Preserves the existing history (so #151 cost/savings
+// don't reset on upgrade) and clears the old copy to reclaim default-nvs space.
+// Guarded by a flag in nvs2 so it runs exactly once.
+static void _migrateFromDefaultNvs() {
+    Preferences meta;
+    if (!meta.begin("wbmeta", false, NVS_PART)) return;
+    if (!meta.getBool("migr", false)) {
+        String s;
+        Preferences old;
+        if (old.begin(NVS_NS, true)) {            // read from the DEFAULT nvs
+            s = old.getString(NVS_KEY, "");
+            old.end();
+        }
+        bool moved = (s.length() <= 2);           // "" / "[]" -> nothing to move
+        if (!moved) {
+            Preferences nw;
+            if (nw.begin(NVS_NS, false, NVS_PART)) {
+                moved = nw.putString(NVS_KEY, s) > 0;   // only "moved" if it stuck
+                nw.end();
+            }
+        }
+        // Reclaim the old copy + mark done ONLY once the history is safely in
+        // nvs2 — otherwise leave it in place and retry on the next boot (never
+        // clear a copy we failed to move, or #151 history would be lost).
+        if (moved) {
+            Preferences clr;
+            if (clr.begin(NVS_NS, false)) { clr.clear(); clr.end(); }
+            meta.putBool("migr", true);
+            Log.println("[chargelog] migrated charge-log to nvs2 partition");
+        } else {
+            Log.println("[chargelog] nvs2 migration deferred (write failed) — will retry");
+        }
+    }
+    meta.end();
+}
+
 // ---- public ----
 
 void begin() {
+    _initNvs2();
+    _migrateFromDefaultNvs();
     JsonDocument doc;
     load(doc);
     JsonArray arr = doc.as<JsonArray>();
@@ -155,7 +213,7 @@ void begin() {
     // persisted periodically (saveOpenState); append what we captured as a
     // completed interval so the charge isn't lost, then clear the pending state.
     Preferences po;
-    if (po.begin(NVS_NS, true)) {
+    if (po.begin(NVS_NS, true, NVS_PART)) {
         String s = po.getString(NVS_OPEN, "");
         po.end();
         if (s.length()) {
@@ -186,7 +244,7 @@ void begin() {
             }
             // Clear it (recovered or invalid) so it can't re-append next boot.
             Preferences pw;
-            if (pw.begin(NVS_NS, false)) { pw.remove(NVS_OPEN); pw.end(); }
+            if (pw.begin(NVS_NS, false, NVS_PART)) { pw.remove(NVS_OPEN); pw.end(); }
         }
     }
 }
@@ -322,7 +380,7 @@ uint32_t lastBurstWh()    { return _lastBurstWh; }
 
 void clear() {
     Preferences p;
-    if (p.begin(NVS_NS, false)) { p.remove(NVS_KEY); p.end(); }
+    if (p.begin(NVS_NS, false, NVS_PART)) { p.remove(NVS_KEY); p.end(); }
     _count = 0;
     _lastBurstWh = 0;
     // Leave any open burst running — clear() only wipes stored history.

--- a/src/wb_cmd.cpp
+++ b/src/wb_cmd.cpp
@@ -1,0 +1,112 @@
+#include "wb_cmd.h"
+#include "wb_ble.h"
+#include "wb_control.h"
+#include "wb_log.h"
+#include "bapi.h"
+
+namespace wb_cmd {
+
+Plan buildCommand(const String& action, const String& value,
+                  const String& owner, const String& metParam,
+                  const String& parParam) {
+    Plan p;
+
+    // Idempotent start/stop (#23): skip a start that's already charging, or a
+    // stop that's already stopped. Some chargers (e.g. Pulsar Plus USA fw) treat
+    // a redundant w_cha as a TOGGLE and flip the wrong way; skipping also avoids
+    // a needless BLE round-trip. Report success — already in the target state.
+    if ((action == "start" || action == "stop") &&
+        wallboxBLE.startStopRedundant(action == "start")) {
+        Log.printf("[CMD] %s SKIPPED as redundant (isCharging=%d)\n",
+                   action.c_str(), (int)wallboxBLE.isCharging());
+        p.outcome     = Plan::RESPOND;
+        p.statusCode  = 200;
+        p.responseJson = "{\"status\":\"ok\",\"skipped\":\"already-in-target-state\"}";
+        return p;
+    }
+
+    // Tag the commander for arbitration (advisory; see docs/control-owner.md).
+    // Charge-affecting actions record who issued them (empty owner -> "manual")
+    // so controllers can detect a recent manual/other override.
+    if (action == "start" || action == "stop" ||
+        action == "resume" || action == "current") {
+        wb_control::recordCommand(owner);
+    }
+
+    p.outcome = Plan::ENQUEUE;
+    if (action == "start") {
+        p.met = bapi::MET_START_STOP;
+        p.par = "1";
+    }
+    // w_cha stop par follows the charger's PRODUCT (chg_project), not the BLE
+    // transport the auto-switch adopts: Pulsar Plus family -> par=0 (pause; a
+    // Plus ACKs par=2 but ignores it, #4/#99), Pulsar MAX -> par=2 (hard stop).
+    // A Plus on the Max single-char stack is still a Plus (par=0) — confirmed on
+    // a prj08-pulsar-plus-pm3. isPlusCommandFamily() reads chg_project, falling
+    // back to the configured model until fw_v_ is read.
+    else if (action == "stop") {
+        p.met = bapi::MET_START_STOP;
+        p.par = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
+        Log.printf("[CMD] stop: chg_project='%s' inferred='%s' isPlusCmd=%d -> w_cha par=%s\n",
+                   wallboxBLE.chargerProject().c_str(), wallboxBLE.inferredModel().c_str(),
+                   (int)wallboxBLE.isPlusCommandFamily(), p.par.c_str());
+    }
+    // Resume clears the schedule/eco manual-override flag (r_dat.gen -> 0).
+    // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging, so we
+    // queue a defensive Stop first in that case alone. Sending the hard Stop
+    // (par=2 on the MAX) when merely paused/waiting is NOT a harmless no-op — it
+    // can fault the charger (error 114), so we skip it unless actually charging.
+    else if (action == "resume") {
+        if (wallboxBLE.isCharging()) {
+            const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
+            wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
+        }
+        p.met = "s_cmode";
+        p.par = "{\"mode\":0}";
+    }
+    else if (action == "lock") {
+        p.met = bapi::MET_LOCK;
+        p.par = "1";
+    }
+    else if (action == "unlock") {
+        p.met = bapi::MET_LOCK;
+        p.par = "0";
+    }
+    // Clamp to the charger's own envelope (6 A .. charger-reported ceiling, #39).
+    // Hard-coding 32 A capped 40 A USA Pulsar Plus units; maxCurrentCeiling()
+    // falls back to 32 A when the charger doesn't report one. toInt()==0 on
+    // garbage -> safe 6 A floor.
+    else if (action == "current") {
+        int amps = value.toInt();
+        int hi = wallboxBLE.maxCurrentCeiling();
+        if (amps < 6)  amps = 6;
+        if (amps > hi) amps = hi;
+        p.met = bapi::MET_SET_CURRENT;
+        p.par = String(amps);
+    }
+    else if (action == "reboot") {
+        p.met = bapi::MET_REBOOT;
+        p.par = "null";
+    }
+    // Raw BAPI passthrough. Unlike the old sync copy (which forwarded an empty
+    // met straight to the charger), a missing met is now a clean 400 — matching
+    // what the async copy already did.
+    else if (action == "bapi") {
+        if (metParam.isEmpty()) {
+            p.outcome     = Plan::RESPOND;
+            p.statusCode  = 400;
+            p.responseJson = "{\"error\":\"missing met\"}";
+            return p;
+        }
+        p.met = metParam;
+        p.par = parParam.isEmpty() ? String("null") : parParam;
+    }
+    else {
+        p.outcome     = Plan::RESPOND;
+        p.statusCode  = 400;
+        p.responseJson = "{\"error\":\"unknown action\"}";
+    }
+    return p;
+}
+
+}  // namespace wb_cmd

--- a/src/wb_mqtt.cpp
+++ b/src/wb_mqtt.cpp
@@ -868,6 +868,11 @@ void WallboxMQTT::publishAvailability(bool online) {
 
 void WallboxMQTT::publishResponse(const char* method, const String& json) {
     if (!isConnected()) return;
+    // Never publish an empty payload — HA renders it as state '' and a numeric
+    // sensor bound to the topic (e.g. ble_rssi on response/gateway) logs
+    // "Invalid state message ''" (#31). Callers mostly guard already; this is
+    // the belt-and-suspenders backstop so no path can emit an empty state.
+    if (json.isEmpty()) return;
     String topic = baseTopic() + "/response/" + method;
     _client->beginPublish(topic.c_str(), json.length(), false);
     _client->print(json);
@@ -1113,7 +1118,10 @@ const DiscoveryEntry kEntries[] = {
     // ----- Group 3: meter + BLE rssi (cases 18-22) -----
 
     /* 18 */ { EntityKind::SENSOR, "ble_rssi", "BLE Signal", "mdi:bluetooth-connect",
-               TopicSlot::GATEWAY, "{{ value_json.rssi }}",
+               // default(0): the ONLY numeric GATEWAY sensor that lacked a guard
+               // — a missing/unparseable rssi rendered '' and HA logged an
+               // "Invalid state message ''" for this signal_strength sensor (#31).
+               TopicSlot::GATEWAY, "{{ value_json.rssi | default(0) }}",
                "dBm", "signal_strength", "measurement", "diagnostic",
                TopicSlot::NONE, 0,0,0, nullptr, nullptr, nullptr, nullptr, 0 },
 

--- a/src/wb_web.cpp
+++ b/src/wb_web.cpp
@@ -1,6 +1,7 @@
 #include "wb_web.h"
 #include "wb_config.h"
 #include "wb_control.h"
+#include "wb_cmd.h"
 #include "wb_ble.h"
 #include "wb_log.h"
 #include "wb_version.h"
@@ -1101,76 +1102,20 @@ static void handleApiCommand() {
     }
 
     // Resolve action → met + par (shared by both paths).
+    // Resolve action -> met + par via the shared planner (#179 — the single
+    // copy of the action mapping / clamps / model logic that both the sync and
+    // async handlers use, so they can't drift). `plan` lives to the end of the
+    // handler; enqueueRequest copies met/par, so plan.met.c_str() is safe below.
     String action = http.arg("action");
-    String value  = http.arg("value");
-    // Idempotent start/stop (#23): skip a start that's already charging, or a
-    // stop that's already stopped — some chargers treat a redundant w_cha as a
-    // TOGGLE and flip the wrong way. Report success (already in target state).
-    if ((action == "start" || action == "stop") &&
-        wallboxBLE.startStopRedundant(action == "start")) {
-        Log.printf("[CMD] %s SKIPPED as redundant (isCharging=%d)\n",
-                   action.c_str(), (int)wallboxBLE.isCharging());
-        http.send(200, "application/json",
-            "{\"status\":\"ok\",\"skipped\":\"already-in-target-state\"}");
+    wb_cmd::Plan plan = wb_cmd::buildCommand(
+        action, http.arg("value"), http.arg("owner"),
+        http.arg("met"), http.arg("par"));
+    if (plan.outcome == wb_cmd::Plan::RESPOND) {
+        http.send(plan.statusCode, "application/json", plan.responseJson);
         return;
     }
-    // Tag the commander for arbitration (advisory; see docs/control-owner.md).
-    // Charge-affecting actions record who issued them (optional &owner=, "" ->
-    // "manual") so controllers can detect a recent manual/other override.
-    if (action == "start" || action == "stop" || action == "resume" || action == "current")
-        wb_control::recordCommand(http.arg("owner"));
-    const char* met = nullptr;
-    String par;
-    if      (action == "start")   { met = bapi::MET_START_STOP;  par = "1"; }
-    // w_cha stop par follows the charger's PRODUCT (chg_project), not the BLE
-    // transport: Pulsar Plus family -> par=0 (pause; a Plus ACKs par=2 but
-    // ignores it, see #99), Pulsar MAX -> par=2 (hard stop). A Plus on the Max
-    // single-char stack is still a Plus (par=0) — confirmed on a forum report's
-    // prj08-pulsar-plus-pm3. isPlusCommandFamily() reads chg_project, falling
-    // back to the configured model until fw_v_ is read.
-    else if (action == "stop")    {
-        met = bapi::MET_START_STOP;
-        par = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
-        Log.printf("[CMD] stop: chg_project='%s' inferred='%s' isPlusCmd=%d -> w_cha par=%s\n",
-                   wallboxBLE.chargerProject().c_str(), wallboxBLE.inferredModel().c_str(),
-                   (int)wallboxBLE.isPlusCommandFamily(), par.c_str());
-    }
-    // Resume — clears schedule/eco override flag (r_dat.gen -> 0).
-    // s_cmode mode=0 is rejected (subcode 6) ONLY while actively charging,
-    // so we queue a defensive Stop first in that case alone. Sending the
-    // hard Stop (par=2 on the MAX) when merely paused/waiting is NOT a
-    // harmless no-op — it can fault the charger (error 114), so we skip it.
-    else if (action == "resume")  {
-        if (wallboxBLE.isCharging()) {
-            const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
-            wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
-        }
-        met = "s_cmode";             par = "{\"mode\":0}";
-    }
-    else if (action == "lock")    { met = bapi::MET_LOCK;        par = "1"; }
-    else if (action == "unlock")  { met = bapi::MET_LOCK;        par = "0"; }
-    else if (action == "current") {
-        // Clamp to the charger's own envelope (6 A .. charger-reported ceiling,
-        // #39). Hard-coding 32 A capped 40 A USA Pulsar Plus units; the ceiling
-        // falls back to 32 A when the charger doesn't report one.
-        met = bapi::MET_SET_CURRENT;
-        int amps = value.toInt();
-        int hi = wallboxBLE.maxCurrentCeiling();
-        if (amps < 6)  amps = 6;
-        if (amps > hi) amps = hi;
-        par = String(amps);
-    }
-    else if (action == "reboot")  { met = bapi::MET_REBOOT;      par = "null"; }
-    else if (action == "bapi") {
-        static String s_met;  // outlives this scope via c_str() below
-        s_met = http.arg("met");
-        met = s_met.c_str();
-        par = http.arg("par");
-        if (par.isEmpty()) par = "null";
-    } else {
-        http.send(400, "application/json", "{\"error\":\"unknown action\"}");
-        return;
-    }
+    const char* met = plan.met.c_str();
+    String par = plan.par;
 
     // Sync escape hatch: preserves the pre-2.7.0 byte-for-byte
     // response shape AND the inflight cap for callers that rely on

--- a/src/wb_web_async.cpp
+++ b/src/wb_web_async.cpp
@@ -11,6 +11,7 @@
 #include "wb_web.h"  // for webServer.requestReboot()
 #include "bapi.h"     // for MET_* constants used in /api/command
 #include "wb_control.h"  // last-command-by tracking for arbitration
+#include "wb_cmd.h"      // shared /api/command action resolver (#179)
 
 #if WB_ASYNC_WEB
 
@@ -995,92 +996,22 @@ static void _registerBleRoutes() {
         // treat w_cha as a TOGGLE, so a redundant write flips the state the wrong
         // way; skipping also avoids a needless BLE round-trip. Report success —
         // we're already in the requested state.
-        if ((action == "start" || action == "stop") &&
-            wallboxBLE.startStopRedundant(action == "start")) {
-            req->send(200, "application/json",
-                "{\"status\":\"ok\",\"skipped\":\"already-in-target-state\"}");
+        // Resolve action -> met + par via the shared planner (#179 — the single
+        // copy both handlers use so the mapping / clamps / model logic can't
+        // drift). `plan` lives to the end of the lambda; enqueueRequest copies
+        // met/par, so plan.met.c_str() is safe below and no per-request String
+        // storage / onDisconnect cleanup is needed anymore.
+        wb_cmd::Plan plan = wb_cmd::buildCommand(
+            action, value,
+            req->hasParam("owner") ? req->getParam("owner")->value() : String(""),
+            req->hasParam("met")   ? req->getParam("met")->value()   : String(""),
+            req->hasParam("par")   ? req->getParam("par")->value()   : String(""));
+        if (plan.outcome == wb_cmd::Plan::RESPOND) {
+            req->send(plan.statusCode, "application/json", plan.responseJson);
             return;
         }
-        // Tag the commander for arbitration (advisory; see docs/control-owner.md).
-        // Charge-affecting actions record who issued them (optional &owner=, ""
-        // -> "manual") so controllers can detect a recent manual/other override.
-        if (action == "start" || action == "stop" || action == "resume" || action == "current") {
-            wb_control::recordCommand(
-                req->hasParam("owner") ? req->getParam("owner")->value() : String(""));
-        }
-        const char* met = nullptr;
-        String par;
-        if      (action == "start")   { met = bapi::MET_START_STOP;  par = "1"; }
-        // w_cha stop par follows the charger's PRODUCT (chg_project), not the
-        // BLE transport the auto-switch adopts: Pulsar Plus family -> par=0
-        // (a Plus ACKs par=2 but ignores it, #4/#99), Pulsar MAX -> par=2. A
-        // Plus on the Max single-char stack is still a Plus (par=0) — confirmed
-        // on a prj08-pulsar-plus-pm3. isPlusCommandFamily() reads
-        // chg_project, falling back to the configured model until fw_v_ is read.
-        else if (action == "stop")    {
-            met = bapi::MET_START_STOP;
-            par = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
-            Log.printf("[CMD] stop: chg_project='%s' inferred='%s' isPlusCmd=%d -> w_cha par=%s\n",
-                       wallboxBLE.chargerProject().c_str(), wallboxBLE.inferredModel().c_str(),
-                       (int)wallboxBLE.isPlusCommandFamily(), par.c_str());
-        }
-        // Resume clears the schedule/eco manual-override flag
-        // (r_dat.gen != 0 -> 0). The charger rejects s_cmode mode=0
-        // (subcode 6) ONLY when actively charging (st=1), so we queue a
-        // defensive Stop first in that case alone. The earlier assumption
-        // that Stop is a harmless no-op when not charging proved WRONG: a
-        // hard Stop (par=2 on the MAX) while merely paused/waiting can fault
-        // the charger (error 114), so we skip it unless actually charging.
-        // s_cmode mode=0 alone lands gen=0 from the paused/idle state.
-        else if (action == "resume")  {
-            if (wallboxBLE.isCharging()) {
-                const char* stopPar = wallboxBLE.isPlusCommandFamily() ? "0" : "2";
-                wallboxBLE.enqueueRequest(bapi::MET_START_STOP, stopPar);
-            }
-            met = "s_cmode";             par = "{\"mode\":0}";
-        }
-        else if (action == "lock")    { met = bapi::MET_LOCK;        par = "1"; }
-        else if (action == "unlock")  { met = bapi::MET_LOCK;        par = "0"; }
-        else if (action == "current") {
-            // Clamp to the charger's own current envelope (it can misbehave on
-            // an out-of-range setpoint). The upper bound is the charger-reported
-            // ceiling (maxCurrentCeiling(), #39) — hard-coding 32 A capped 40 A
-            // USA Pulsar Plus units. Falls back to 32 A when unreported. MQTT +
-            // integration also clamp; the web paths forwarded `value` raw.
-            // toInt()==0 on garbage -> safe 6 A floor.
-            met = bapi::MET_SET_CURRENT;
-            int amps = value.toInt();
-            int hi = wallboxBLE.maxCurrentCeiling();
-            if (amps < 6)  amps = 6;
-            if (amps > hi) amps = hi;
-            par = String(amps);
-        }
-        else if (action == "reboot")  { met = bapi::MET_REBOOT;      par = "null"; }
-        else if (action == "bapi") {
-            // Use a per-request String for the met arg so its c_str()
-            // outlives the lookup below. The static trick from sync
-            // handler isn't safe across AsyncTCP requests.
-            String userMet = req->hasParam("met")
-                ? req->getParam("met")->value() : String("");
-            if (userMet.length() == 0) {
-                req->send(400, "application/json",
-                    "{\"error\":\"missing met\"}");
-                return;
-            }
-            // Stash on the request's tempObject for the lifetime of
-            // the handler. We dispose at the bottom.
-            String* metStorage = new String(userMet);
-            met = metStorage->c_str();
-            par = req->hasParam("par")
-                ? req->getParam("par")->value() : String("null");
-            if (par.isEmpty()) par = "null";
-            // We'll delete this at end of handler — see below.
-            req->onDisconnect([metStorage]() { delete metStorage; });
-        } else {
-            req->send(400, "application/json",
-                "{\"error\":\"unknown action\"}");
-            return;
-        }
+        const char* met = plan.met.c_str();
+        String par = plan.par;
 
         // Async path. Enqueue with WAKE_AND_MQTT so a missed wake
         // still publishes to wallbox/response/<met> for polling.


### PR DESCRIPTION
## Summary
Bundles three verified changes, integration-tested together on a Pulsar MAX Pro:

- **#179** — single shared `/api/command` action resolver (`wb_cmd`), killing the sync/async handler drift that caused the Kenneth Stop saga + the v3.2.5 review catch. Behavior-preserving (reviewed clean); sync `bapi` missing-met now 400 to match async.
- **#154** — classic ESP32-WROOM (`esp32dev`) build target; the S3 moves to an 8 MB partition table (3 MB OTA app slots, app 74%→46% of slot); the charge-log moves to its own `nvs2` partition (off the crowded default `nvs`, the #166 cause) with a one-time history migration; `MAX_INTERVALS` 24→96 on the S3 so month cost/savings don't undercount.
- **#31** — stop the `Invalid state message ''` log spam (empty-payload guard on `publishResponse` + `default(0)` on the `ble_rssi` template).

**Hardware-validated as one build:** clean boot + BLE, current-set/bapi/stop-skip/unlock all work, charge-log migrated intact (24 preserved in nvs2), rssi numeric. Both targets build (S3 46%, WROOM 80%).

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)