### PR TITLE
v3.2.9 — report real board for -e ota builds + ship esp32dev OTA asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,13 @@ jobs:
           # commit. Debug artifact only; never flashed.
           cp .pio/build/esp32s3/firmware.elf \
              ".pio/build/esp32s3/wallbox-gateway-${GITHUB_REF_NAME}-esp32s3.elf"
+          # Classic ESP32-WROOM (esp32dev, #154): a board-named .bin so WROOM
+          # gateways (board="esp32dev") can OTA from HA too — pick_asset needs a
+          # '-esp32dev.bin' or it fails with "no firmware asset for board".
+          cp .pio/build/esp32dev/firmware.bin \
+             ".pio/build/esp32dev/wallbox-gateway-${GITHUB_REF_NAME}-esp32dev.bin"
+          cp .pio/build/esp32dev/firmware.elf \
+             ".pio/build/esp32dev/wallbox-gateway-${GITHUB_REF_NAME}-esp32dev.elf"
 
       - name: Attach to release
         if: github.event_name == 'release'
@@ -139,3 +146,5 @@ jobs:
             .pio/build/esp32s3/partitions.bin
             .pio/build/esp32s3/SHA256SUMS.txt
             .pio/build/esp32s3/install.json
+            .pio/build/esp32dev/wallbox-gateway-*-esp32dev.bin
+            .pio/build/esp32dev/wallbox-gateway-*-esp32dev.elf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [3.2.9] - 2026-08-21
+
+### Fixed
+- **`/api/status.board` now reports the real target when flashed via the `ota`
+  env.** `WB_BOARD` was set to the PlatformIO env name, so a gateway flashed with
+  `pio run -e ota -t upload` reported `board="ota"` — which the HA Update entity
+  couldn't match to a release asset (`-ota.bin` doesn't exist). The `ota` env is
+  only an espota upload convenience that extends `esp32s3`, so it now reports
+  `esp32s3`. (The integration also gained a fallback for already-flashed
+  gateways — see hass-wallbox-gateway v0.33.1.)
+- **Releases now attach a classic ESP32-WROOM (`esp32dev`) OTA binary.** The
+  build workflow already compiled `esp32dev` (#154) but only kept it as a CI
+  artifact, so WROOM gateways (`board="esp32dev"`) had no release asset to OTA
+  from Home Assistant. Releases now ship `wallbox-gateway-<tag>-esp32dev.bin`
+  alongside the esp32s3 one.
 
 ## [3.2.8] - 2026-08-19
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -59,6 +59,10 @@ env.Append(CPPDEFINES=[("WB_VERSION", env.StringifyMacro(version))])  # type: ig
 # the suffix on the release binary asset (wallbox-gateway-<ver>-esp32s3.bin).
 # Surfaced in /api/status.board so the HA integration's Update entity can fetch
 # the matching asset for OTA. Single source of truth — no separate board string.
-board = env["PIOENV"]  # type: ignore
+# The `ota` env is only a convenience for `pio run -e ota -t upload` (espota);
+# it EXTENDS esp32s3, so report the real target it builds — otherwise a gateway
+# flashed that way reports board="ota" and the Update entity finds no asset.
+_ENV_BOARD_ALIAS = {"ota": "esp32s3"}
+board = _ENV_BOARD_ALIAS.get(env["PIOENV"], env["PIOENV"])  # type: ignore
 print(f"[version.py] WB_BOARD = {board}")
 env.Append(CPPDEFINES=[("WB_BOARD", env.StringifyMacro(board))])  # type: ignore


### PR DESCRIPTION
Firmware v3.2.9 — completes the OTA board-matching fix (companion to integration v0.33.1).

## Fixed
- **`/api/status.board` reports the real target for `-e ota` builds.** `WB_BOARD` was the PlatformIO env name, so `pio run -e ota -t upload` produced firmware reporting `board="ota"` — which the HA Update entity can't match to a release asset. The `ota` env only adds espota upload and `extends = env:esp32s3`, so it now reports `esp32s3`.
- **Releases attach a classic ESP32-WROOM (`esp32dev`) OTA binary.** The workflow already built esp32dev (#154) but kept it as a CI artifact only, so WROOM gateways had no release asset to OTA from HA. Releases now ship `wallbox-gateway-<tag>-esp32dev.bin`.

No runtime firmware logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)